### PR TITLE
fix: resolve rateshift.app site-audit findings (Analytics 500s, suppliers 405/$0, blank pages, community count)

### DIFF
--- a/backend/api/v1/suppliers.py
+++ b/backend/api/v1/suppliers.py
@@ -95,6 +95,9 @@ async def list_suppliers(
         description="Filter by utility type (electricity, natural_gas, heating_oil, propane, community_solar)",
     ),
     green_only: bool = Query(False, description="Filter for green energy providers"),
+    annual_usage: float | None = Query(
+        None, ge=0, description="Annual usage in kWh, used to estimate annual cost"
+    ),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(20, ge=1, le=100, description="Items per page"),
     db=Depends(get_db_session),
@@ -106,6 +109,12 @@ async def list_suppliers(
     Returns paginated list of suppliers, optionally filtered by region,
     utility type, or green energy status. Data is sourced from the
     supplier_registry table. Results are cached in Redis for 1 hour.
+
+    Pricing (``avg_price_per_kwh`` / ``estimated_annual_cost``) is estimated
+    from the regional electricity market rate when ``region`` (and, for the
+    cost, ``annual_usage``) are supplied. There is no per-supplier tariff data
+    yet, so all suppliers share the regional rate — same approach as the
+    dashboard. Fields stay null when no market rate is available.
     """
     repo = SupplierRegistryRepository(db, cache=redis)
     suppliers_data, total = await repo.list_suppliers(
@@ -119,6 +128,19 @@ async def list_suppliers(
 
     suppliers = [SupplierResponse(**s) for s in suppliers_data]
 
+    # Estimate pricing from the regional market rate (no per-supplier tariffs).
+    if region and suppliers:
+        try:
+            market_rate = await repo.get_region_market_rate(region)
+        except Exception:
+            logger.warning("supplier_market_rate_lookup_failed", region=region, exc_info=True)
+            market_rate = None
+        if market_rate is not None:
+            est_cost = round(market_rate * annual_usage, 2) if annual_usage else None
+            for supplier in suppliers:
+                supplier.avg_price_per_kwh = market_rate
+                supplier.estimated_annual_cost = est_cost
+
     return SuppliersResponse(
         suppliers=suppliers,
         total=total,
@@ -127,6 +149,35 @@ async def list_suppliers(
         region=region,
         utility_type=utility_type,
     )
+
+
+class RecommendRequest(BaseModel):
+    """Body for POST /suppliers/recommend (camelCase to match the frontend)."""
+
+    currentSupplierId: str | None = None
+    annualUsage: float | None = None
+    region: str | None = None
+
+
+@router.post("/recommend", summary="Get a supplier switching recommendation")
+async def recommend_supplier(
+    body: RecommendRequest,
+    db=Depends(get_db_session),
+    redis=Depends(get_redis),
+):
+    """Return a switching recommendation, or ``null`` when none can be computed.
+
+    Per-supplier tariff data does not exist yet (the ``tariffs`` table is empty
+    and not linked to ``supplier_registry``), so there is no basis for
+    supplier-specific savings — every supplier is priced at the same regional
+    market rate. We therefore return ``{"recommendation": null}`` (HTTP 200)
+    instead of fabricating a savings figure.
+
+    This route previously did not exist, so a POST fell through to
+    ``GET /{supplier_id}`` and returned 405. Defining it fixes the 405. When
+    real tariffs are seeded, compute and return the cheapest alternative here.
+    """
+    return {"recommendation": None}
 
 
 @router.get("/registry", summary="List suppliers with API integration")

--- a/backend/models/supplier.py
+++ b/backend/models/supplier.py
@@ -175,6 +175,13 @@ class SupplierResponse(BaseModel):
     rating: float | None = None
     green_energy_provider: bool
     is_active: bool
+    # Estimated pricing. There is no per-supplier tariff data yet (the tariffs
+    # table is empty and unlinked from supplier_registry), so these are derived
+    # from the regional electricity market rate — the same source the dashboard
+    # uses — rather than a per-supplier contract. Null when no market rate or
+    # annual usage is available.
+    avg_price_per_kwh: float | None = None
+    estimated_annual_cost: float | None = None
 
 
 class SupplierDetailResponse(BaseModel):

--- a/backend/repositories/supplier_repository.py
+++ b/backend/repositories/supplier_repository.py
@@ -225,6 +225,26 @@ class SupplierRegistryRepository:
         except Exception as e:
             raise RepositoryError(f"Failed to list suppliers: {str(e)}", e)
 
+    async def get_region_market_rate(self, region: str) -> float | None:
+        """Latest electricity market price for a region in $/kWh.
+
+        Used as an estimated supplier rate because per-supplier tariff data
+        does not yet exist (the tariffs table is empty and not linked to
+        supplier_registry). Returns None when no price rows exist for the
+        region. Raises on a genuine DB error rather than silently degrading.
+        The enum literal is lowercase to match the Postgres utility_type enum.
+        """
+        result = await self._db.execute(
+            text(
+                "SELECT price_per_kwh FROM electricity_prices"
+                " WHERE region = :region AND utility_type = 'electricity'"
+                " ORDER BY timestamp DESC LIMIT 1"
+            ),
+            {"region": region.lower()},
+        )
+        row = result.scalar()
+        return float(row) if row is not None else None
+
     async def get_by_id(self, supplier_id: str) -> dict | None:
         """
         Get a single supplier by its UUID.

--- a/backend/services/community_service.py
+++ b/backend/services/community_service.py
@@ -601,6 +601,7 @@ class CommunityService:
         stats_sql = text("""
             SELECT
                 COUNT(DISTINCT user_id) AS total_users,
+                COUNT(*) AS post_count,
                 MIN(created_at) AS earliest_post
             FROM community_posts
             WHERE region = :region
@@ -633,6 +634,7 @@ class CommunityService:
 
         return {
             "total_users": stats["total_users"] if stats else 0,
+            "post_count": stats["post_count"] if stats else 0,
             "region": region,
             "reporting_since": stats["earliest_post"] if stats else None,
             "top_tip": dict(top_tip) if top_tip else None,

--- a/backend/services/forecast_service.py
+++ b/backend/services/forecast_service.py
@@ -37,7 +37,7 @@ _ALLOWED_COLS = frozenset(
 # Allowlisted static WHERE clauses (defense-in-depth: prevents future callers
 # from accidentally passing user-controlled SQL fragments).
 _ALLOWED_WHERE_CLAUSES: frozenset[str | None] = frozenset(
-    {None, "utility_type = 'NATURAL_GAS'", "utility_type = 'ELECTRICITY'"}
+    {None, "utility_type = 'natural_gas'", "utility_type = 'electricity'"}
 )
 
 
@@ -88,7 +88,7 @@ class ForecastService:
                 table="electricity_prices",
                 price_col="price_per_kwh",
                 unit="$/therm",
-                where_clause="utility_type = 'NATURAL_GAS'",
+                where_clause="utility_type = 'natural_gas'",
                 state=state,
                 state_col="region",
                 state_prefix="us_",
@@ -139,7 +139,7 @@ class ForecastService:
                     AVG(price_per_kwh) AS price_per_kwh,
                     DATE_TRUNC('day', timestamp) AS timestamp
                 FROM electricity_prices
-                WHERE utility_type = 'ELECTRICITY'
+                WHERE utility_type = 'electricity'
                   AND timestamp >= NOW() - make_interval(days => :lookback_days)
                   {region_filter}
                 GROUP BY DATE_TRUNC('day', timestamp)

--- a/backend/services/optimization_report_service.py
+++ b/backend/services/optimization_report_service.py
@@ -110,21 +110,21 @@ class OptimizationReportService:
                            ) AS rn
                     FROM electricity_prices
                     WHERE region = :region
-                      AND utility_type IN ('ELECTRICITY', 'NATURAL_GAS')
+                      AND utility_type IN ('electricity', 'natural_gas')
                 )
                 SELECT price_per_kwh, supplier, utility_type
                 FROM recent_prices
-                WHERE (utility_type = 'ELECTRICITY' AND rn <= 10)
-                   OR (utility_type = 'NATURAL_GAS' AND rn <= 5)
+                WHERE (utility_type = 'electricity' AND rn <= 10)
+                   OR (utility_type = 'natural_gas' AND rn <= 5)
                 ORDER BY utility_type, rn
             """),
             {"region": f"us_{state.lower()}"},
         )
         rows = result.mappings().all()
 
-        # Partition results by utility_type
-        elec_rows = [r for r in rows if r["utility_type"] == "ELECTRICITY"]
-        gas_rows = [r for r in rows if r["utility_type"] == "NATURAL_GAS"]
+        # Partition results by utility_type (DB enum stores lowercase values)
+        elec_rows = [r for r in rows if r["utility_type"] == "electricity"]
+        gas_rows = [r for r in rows if r["utility_type"] == "natural_gas"]
 
         elec = self._build_electricity_result(elec_rows) if elec_rows else None
         gas = self._build_gas_result(gas_rows) if gas_rows else None

--- a/backend/services/rate_export_service.py
+++ b/backend/services/rate_export_service.py
@@ -27,7 +27,7 @@ EXPORT_CONFIGS = {
         "time_col": "timestamp",
         "state_col": "region",
         "state_prefix": "us_",
-        "extra_where": "utility_type = 'ELECTRICITY'",
+        "extra_where": "utility_type = 'electricity'",
         "unit": "$/kWh",
     },
     "natural_gas": {
@@ -37,7 +37,7 @@ EXPORT_CONFIGS = {
         "time_col": "timestamp",
         "state_col": "region",
         "state_prefix": "us_",
-        "extra_where": "utility_type = 'NATURAL_GAS'",
+        "extra_where": "utility_type = 'natural_gas'",
         "unit": "$/therm",
     },
     "heating_oil": {

--- a/backend/tests/test_api_suppliers.py
+++ b/backend/tests/test_api_suppliers.py
@@ -144,3 +144,70 @@ class TestCompareSuppliers:
             resp = client.get(f"{_BASE}/compare/us_ct")
         assert resp.status_code == 200
         assert resp.json()["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /suppliers/recommend  (audit 2026-05-21: was 405)
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendEndpoint:
+    def test_post_recommend_returns_200_not_405(self, client):
+        """Regression: the route exists, so POST is no longer 405 (it used to
+        fall through to GET /{supplier_id})."""
+        resp = client.post(
+            f"{_BASE}/recommend",
+            json={
+                "currentSupplierId": "sup-001",
+                "annualUsage": 10500,
+                "region": "us_ct",
+            },
+        )
+        assert resp.status_code == 200
+        assert "recommendation" in resp.json()
+
+    def test_post_recommend_accepts_empty_body(self, client):
+        resp = client.post(f"{_BASE}/recommend", json={})
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /suppliers/ estimated pricing  (audit 2026-05-21: all prices were $0.00)
+# ---------------------------------------------------------------------------
+
+
+class TestEstimatedPricing:
+    def test_annual_usage_param_accepted_and_cost_estimated(self, client):
+        with (
+            patch(
+                "repositories.supplier_repository.SupplierRegistryRepository.list_suppliers",
+                new=AsyncMock(return_value=([dict(_SUPPLIER_ROW)], 1)),
+            ),
+            patch(
+                "repositories.supplier_repository.SupplierRegistryRepository.get_region_market_rate",
+                new=AsyncMock(return_value=0.25),
+            ),
+        ):
+            resp = client.get(f"{_BASE}/?region=us_ct&annual_usage=10500")
+        assert resp.status_code == 200
+        supplier = resp.json()["suppliers"][0]
+        assert supplier["avg_price_per_kwh"] == 0.25
+        # 0.25 * 10500 = 2625.0 — no longer the $0.00 the audit observed.
+        assert supplier["estimated_annual_cost"] == 2625.0
+
+    def test_price_null_when_no_market_rate(self, client):
+        with (
+            patch(
+                "repositories.supplier_repository.SupplierRegistryRepository.list_suppliers",
+                new=AsyncMock(return_value=([dict(_SUPPLIER_ROW)], 1)),
+            ),
+            patch(
+                "repositories.supplier_repository.SupplierRegistryRepository.get_region_market_rate",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            resp = client.get(f"{_BASE}/?region=us_ct&annual_usage=10500")
+        assert resp.status_code == 200
+        supplier = resp.json()["suppliers"][0]
+        assert supplier["avg_price_per_kwh"] is None
+        assert supplier["estimated_annual_cost"] is None

--- a/backend/tests/test_community_service.py
+++ b/backend/tests/test_community_service.py
@@ -782,6 +782,7 @@ class TestCommunityStats:
         stats_result = MagicMock()
         stats_result.mappings.return_value.fetchone.return_value = {
             "total_users": 42,
+            "post_count": 87,
             "earliest_post": datetime(2026, 1, 1, tzinfo=UTC),
         }
 
@@ -802,6 +803,7 @@ class TestCommunityStats:
         stats = await service.get_stats(mock_db, region="us_ct")
 
         assert stats["total_users"] == 42
+        assert stats["post_count"] == 87
         assert stats["region"] == "us_ct"
         assert stats["reporting_since"] is not None
         assert stats["top_tip"] is not None

--- a/backend/tests/test_forecast_service.py
+++ b/backend/tests/test_forecast_service.py
@@ -254,3 +254,30 @@ class TestForecastEdgeCases:
         result = await service.get_forecast("electricity", state="CT")
         assert "error" in result
         assert result["data_points"] == 0
+
+
+# =============================================================================
+# Enum-case regression (audit 2026-05-21)
+# =============================================================================
+
+
+class TestForecastEnumCase:
+    """The DB ``utility_type`` enum stores LOWERCASE values. Uppercase SQL
+    literals ('ELECTRICITY') made Postgres raise ``invalid input value for
+    enum utility_type`` → unhandled 500 on /api/v1/forecast/electricity."""
+
+    async def test_electricity_query_uses_lowercase_enum(self):
+        db = _make_db([])
+        service = ForecastService(db)
+        await service.get_forecast("electricity", state="CT")
+        sql = str(db.execute.call_args.args[0])
+        assert "'electricity'" in sql.lower()
+        assert "'ELECTRICITY'" not in sql
+
+    async def test_natural_gas_query_uses_lowercase_enum(self):
+        db = _make_db([])
+        service = ForecastService(db)
+        await service.get_forecast("natural_gas", state="CT")
+        sql = str(db.execute.call_args.args[0])
+        assert "'natural_gas'" in sql.lower()
+        assert "'NATURAL_GAS'" not in sql

--- a/backend/tests/test_optimization_report_service.py
+++ b/backend/tests/test_optimization_report_service.py
@@ -89,7 +89,7 @@ class TestReportStructure:
 
     async def test_annual_spend_is_12x_monthly(self):
         # CTE query returns electricity rows with utility_type
-        elec_rows = [{"price_per_kwh": 0.15, "supplier": "ACME", "utility_type": "ELECTRICITY"}]
+        elec_rows = [{"price_per_kwh": 0.15, "supplier": "ACME", "utility_type": "electricity"}]
         db = _make_db([elec_rows, [], []])
         service = OptimizationReportService(db)
         result = await service.generate_report("CT")
@@ -104,7 +104,7 @@ class TestReportStructure:
 
 class TestElectricitySpend:
     async def test_monthly_cost_calculation(self):
-        rows = [{"price_per_kwh": 0.20, "supplier": "Test", "utility_type": "ELECTRICITY"}]
+        rows = [{"price_per_kwh": 0.20, "supplier": "Test", "utility_type": "electricity"}]
         db = _make_db([rows, [], []])
         service = OptimizationReportService(db)
         result = await service.generate_report("CT")
@@ -115,8 +115,8 @@ class TestElectricitySpend:
 
     async def test_savings_generated_when_price_spread(self):
         rows = [
-            {"price_per_kwh": 0.25, "supplier": "Expensive", "utility_type": "ELECTRICITY"},
-            {"price_per_kwh": 0.15, "supplier": "Cheap", "utility_type": "ELECTRICITY"},
+            {"price_per_kwh": 0.25, "supplier": "Expensive", "utility_type": "electricity"},
+            {"price_per_kwh": 0.15, "supplier": "Cheap", "utility_type": "electricity"},
         ]
         db = _make_db([rows, [], []])
         service = OptimizationReportService(db)
@@ -137,8 +137,8 @@ class TestMultiUtilityAggregation:
     async def test_utility_count_matches_data(self):
         # CTE returns both electricity and gas rows in one query
         combined_rows = [
-            {"price_per_kwh": 0.15, "supplier": "A", "utility_type": "ELECTRICITY"},
-            {"price_per_kwh": 1.20, "supplier": None, "utility_type": "NATURAL_GAS"},
+            {"price_per_kwh": 0.15, "supplier": "A", "utility_type": "electricity"},
+            {"price_per_kwh": 1.20, "supplier": None, "utility_type": "natural_gas"},
         ]
         db = _make_db([combined_rows, [], []])
         service = OptimizationReportService(db)
@@ -151,8 +151,8 @@ class TestMultiUtilityAggregation:
 
     async def test_total_monthly_aggregates_all(self):
         combined_rows = [
-            {"price_per_kwh": 0.15, "supplier": "A", "utility_type": "ELECTRICITY"},
-            {"price_per_kwh": 1.50, "supplier": None, "utility_type": "NATURAL_GAS"},
+            {"price_per_kwh": 0.15, "supplier": "A", "utility_type": "electricity"},
+            {"price_per_kwh": 1.50, "supplier": None, "utility_type": "natural_gas"},
         ]
         db = _make_db([combined_rows, [], []])
         service = OptimizationReportService(db)
@@ -189,3 +189,37 @@ class TestPropaneSpend:
         prop = result["utilities"][0]
         assert prop["utility_type"] == "propane"
         assert abs(prop["monthly_cost"] - 176.40) < 0.01
+
+
+# =============================================================================
+# 6. Enum-case regression (audit 2026-05-21)
+# =============================================================================
+
+
+class TestEnumCaseSensitivity:
+    """The DB ``utility_type`` enum stores LOWERCASE values. SQL literals that
+    used uppercase ('ELECTRICITY') made Postgres raise ``invalid input value
+    for enum utility_type`` → unhandled 500 on /api/v1/reports/optimization.
+    These tests inspect the generated SQL so the regression can't return."""
+
+    async def test_cte_sql_uses_lowercase_enum_literals(self):
+        db = _make_db([[], [], []])
+        service = OptimizationReportService(db)
+        await service.generate_report("CT")
+
+        # First db.execute call is the electricity+gas CTE merge.
+        first_sql = str(db.execute.call_args_list[0].args[0])
+        assert "'electricity'" in first_sql.lower()
+        assert "'ELECTRICITY'" not in first_sql
+        assert "'NATURAL_GAS'" not in first_sql
+
+    async def test_lowercase_rows_are_not_filtered_out(self):
+        # Rows as the real DB returns them (lowercase) must be counted, not dropped.
+        combined_rows = [
+            {"price_per_kwh": 0.15, "supplier": "A", "utility_type": "electricity"},
+            {"price_per_kwh": 1.20, "supplier": None, "utility_type": "natural_gas"},
+        ]
+        db = _make_db([combined_rows, [], []])
+        service = OptimizationReportService(db)
+        result = await service.generate_report("CT")
+        assert result["utility_count"] == 2

--- a/backend/tests/test_rate_export_service.py
+++ b/backend/tests/test_rate_export_service.py
@@ -52,7 +52,7 @@ class TestExportConfigs:
     def test_natural_gas_config(self):
         cfg = EXPORT_CONFIGS["natural_gas"]
         assert cfg["table"] == "electricity_prices"
-        assert cfg["extra_where"] == "utility_type = 'NATURAL_GAS'"
+        assert cfg["extra_where"] == "utility_type = 'natural_gas'"
 
     def test_heating_oil_config(self):
         cfg = EXPORT_CONFIGS["heating_oil"]

--- a/frontend/__tests__/components/community/Community.test.tsx
+++ b/frontend/__tests__/components/community/Community.test.tsx
@@ -111,10 +111,11 @@ const mockPosts = {
 };
 
 const mockStats = {
-  user_count: 142,
+  total_users: 142,
+  region: "us_ct",
   avg_savings_pct: 18.5,
   post_count: 87,
-  since: "2025-06-01T00:00:00Z",
+  reporting_since: "2025-06-01T00:00:00Z",
   top_tip: { title: "Switch to off-peak hours", id: "tip-1" },
 };
 

--- a/frontend/__tests__/components/community/CommunityStats.test.tsx
+++ b/frontend/__tests__/components/community/CommunityStats.test.tsx
@@ -44,10 +44,11 @@ function setup(statsOverrides: Record<string, unknown> = {}) {
 }
 
 const _stats = {
-  user_count: 142,
+  total_users: 142,
+  region: "us_ct",
   avg_savings_pct: 18.5,
   post_count: 87,
-  since: "2025-01-01T00:00:00Z",
+  reporting_since: "2025-01-01T00:00:00Z",
   top_tip: {
     id: "tip-1",
     title: "Switch to off-peak charging for EVs",
@@ -112,8 +113,8 @@ describe("CommunityStats", () => {
     );
   });
 
-  it("omits attribution when since is absent", () => {
-    setup({ data: { ..._stats, since: null } });
+  it("omits attribution when reporting_since is absent", () => {
+    setup({ data: { ..._stats, reporting_since: null } });
     render(<CommunityStats />);
     expect(screen.queryByTestId("stats-attribution")).not.toBeInTheDocument();
   });

--- a/frontend/__tests__/components/water/WaterRateBenchmark.test.tsx
+++ b/frontend/__tests__/components/water/WaterRateBenchmark.test.tsx
@@ -1,66 +1,99 @@
-import { render, screen } from '@testing-library/react'
-import { WaterRateBenchmark } from '@/components/water/WaterRateBenchmark'
-import '@testing-library/jest-dom'
+import { render, screen } from "@testing-library/react";
+import { WaterRateBenchmark } from "@/components/water/WaterRateBenchmark";
+import "@testing-library/jest-dom";
 
-const mockUseWaterBenchmark = jest.fn()
-jest.mock('@/lib/hooks/useWater', () => ({
+const mockUseWaterBenchmark = jest.fn();
+jest.mock("@/lib/hooks/useWater", () => ({
   useWaterBenchmark: (...args: unknown[]) => mockUseWaterBenchmark(...args),
-}))
+}));
 
 const MOCK_BENCHMARK = {
-  state: 'NY',
+  state: "NY",
   municipalities: 2,
   usage_gallons: 5760,
-  avg_monthly_cost: 45.50,
-  min_monthly_cost: 38.00,
-  max_monthly_cost: 53.00,
+  avg_monthly_cost: 45.5,
+  min_monthly_cost: 38.0,
+  max_monthly_cost: 53.0,
   rates: [
-    { municipality: 'Buffalo', monthly_cost: 38.00, base_charge: 12.00 },
-    { municipality: 'New York', monthly_cost: 53.00, base_charge: 15.50 },
+    { municipality: "Buffalo", monthly_cost: 38.0, base_charge: 12.0 },
+    { municipality: "New York", monthly_cost: 53.0, base_charge: 15.5 },
   ],
-}
+};
 
-describe('WaterRateBenchmark', () => {
+describe("WaterRateBenchmark", () => {
   beforeEach(() => {
-    mockUseWaterBenchmark.mockReset()
-  })
+    mockUseWaterBenchmark.mockReset();
+  });
 
-  it('shows loading skeleton', () => {
-    mockUseWaterBenchmark.mockReturnValue({ data: null, isLoading: true, error: null })
-    const { container } = render(<WaterRateBenchmark state="NY" />)
-    expect(container.querySelector('.animate-pulse')).toBeInTheDocument()
-  })
+  it("shows loading skeleton", () => {
+    mockUseWaterBenchmark.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+    const { container } = render(<WaterRateBenchmark state="NY" />);
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
 
-  it('renders nothing on error', () => {
-    mockUseWaterBenchmark.mockReturnValue({ data: null, isLoading: false, error: new Error('fail') })
-    const { container } = render(<WaterRateBenchmark state="NY" />)
-    expect(container.innerHTML).toBe('')
-  })
+  it("shows an explicit empty-state message on error (no silent fallback)", () => {
+    // ADR-011: errors must surface to the user, not render an empty <div>.
+    mockUseWaterBenchmark.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error("fail"),
+    });
+    render(<WaterRateBenchmark state="NY" />);
+    expect(
+      screen.getByText(/No water rate data is available for NY/i),
+    ).toBeInTheDocument();
+  });
 
-  it('displays benchmark summary cards', () => {
-    mockUseWaterBenchmark.mockReturnValue({ data: MOCK_BENCHMARK, isLoading: false, error: null })
-    render(<WaterRateBenchmark state="NY" />)
+  it("renders nothing only when data is absent without an error", () => {
+    mockUseWaterBenchmark.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
+    const { container } = render(<WaterRateBenchmark state="NY" />);
+    expect(container.innerHTML).toBe("");
+  });
 
-    expect(screen.getByText('Water Rate Benchmark — NY')).toBeInTheDocument()
-    expect(screen.getByText('$45.50')).toBeInTheDocument()
-    expect(screen.getByText('$38.00')).toBeInTheDocument()
-    expect(screen.getByText('$53.00')).toBeInTheDocument()
-  })
+  it("displays benchmark summary cards", () => {
+    mockUseWaterBenchmark.mockReturnValue({
+      data: MOCK_BENCHMARK,
+      isLoading: false,
+      error: null,
+    });
+    render(<WaterRateBenchmark state="NY" />);
 
-  it('displays municipality breakdown', () => {
-    mockUseWaterBenchmark.mockReturnValue({ data: MOCK_BENCHMARK, isLoading: false, error: null })
-    render(<WaterRateBenchmark state="NY" />)
+    expect(screen.getByText("Water Rate Benchmark — NY")).toBeInTheDocument();
+    expect(screen.getByText("$45.50")).toBeInTheDocument();
+    expect(screen.getByText("$38.00")).toBeInTheDocument();
+    expect(screen.getByText("$53.00")).toBeInTheDocument();
+  });
 
-    expect(screen.getByText('New York')).toBeInTheDocument()
-    expect(screen.getByText('Buffalo')).toBeInTheDocument()
-    expect(screen.getByText('Municipality Comparison')).toBeInTheDocument()
-  })
+  it("displays municipality breakdown", () => {
+    mockUseWaterBenchmark.mockReturnValue({
+      data: MOCK_BENCHMARK,
+      isLoading: false,
+      error: null,
+    });
+    render(<WaterRateBenchmark state="NY" />);
 
-  it('shows usage info', () => {
-    mockUseWaterBenchmark.mockReturnValue({ data: MOCK_BENCHMARK, isLoading: false, error: null })
-    render(<WaterRateBenchmark state="NY" />)
+    expect(screen.getByText("New York")).toBeInTheDocument();
+    expect(screen.getByText("Buffalo")).toBeInTheDocument();
+    expect(screen.getByText("Municipality Comparison")).toBeInTheDocument();
+  });
 
-    expect(screen.getByText(/5,760 gallons\/month/)).toBeInTheDocument()
-    expect(screen.getByText(/2 municipalities/)).toBeInTheDocument()
-  })
-})
+  it("shows usage info", () => {
+    mockUseWaterBenchmark.mockReturnValue({
+      data: MOCK_BENCHMARK,
+      isLoading: false,
+      error: null,
+    });
+    render(<WaterRateBenchmark state="NY" />);
+
+    expect(screen.getByText(/5,760 gallons\/month/)).toBeInTheDocument();
+    expect(screen.getByText(/2 municipalities/)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/community/CommunityStats.tsx
+++ b/frontend/components/community/CommunityStats.tsx
@@ -1,38 +1,51 @@
-'use client'
+"use client";
 
-import React from 'react'
-import { Skeleton } from '@/components/ui/skeleton'
-import { useCommunityStats } from '@/lib/hooks/useCommunity'
-import { useSettingsStore } from '@/lib/store/settings'
+import React from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useCommunityStats } from "@/lib/hooks/useCommunity";
+import { useSettingsStore } from "@/lib/store/settings";
 
 export function CommunityStats() {
-  const region = useSettingsStore((s) => s.region)
-  const { data, isLoading, error } = useCommunityStats(region)
+  const region = useSettingsStore((s) => s.region);
+  const { data, isLoading, error } = useCommunityStats(region);
 
   if (isLoading) {
     return (
-      <div data-testid="community-stats-loading" className="rounded-xl border bg-white p-6">
+      <div
+        data-testid="community-stats-loading"
+        className="rounded-xl border bg-white p-6"
+      >
         <Skeleton variant="text" width={300} />
         <Skeleton variant="text" width={200} className="mt-2" />
       </div>
-    )
+    );
   }
 
   if (error || !data) {
-    return null // Gracefully hide stats on error — non-essential
+    return null; // Gracefully hide stats on error — non-essential
   }
 
   return (
-    <div data-testid="community-stats" className="rounded-xl border bg-gradient-to-r from-primary-50 to-blue-50 p-6">
-      <p className="text-sm font-medium text-gray-800" data-testid="stats-banner">
-        {data.user_count} users in your area
+    <div
+      data-testid="community-stats"
+      className="rounded-xl border bg-gradient-to-r from-primary-50 to-blue-50 p-6"
+    >
+      <p
+        className="text-sm font-medium text-gray-800"
+        data-testid="stats-banner"
+      >
+        {data.total_users} users in your area
         {data.avg_savings_pct != null && (
           <> saved an average of {Math.round(data.avg_savings_pct)}%</>
         )}
       </p>
-      {data.since && (
-        <p className="mt-1 text-xs text-gray-500" data-testid="stats-attribution">
-          Based on {data.post_count} reports since {new Date(data.since).toLocaleDateString()}
+      {data.reporting_since && (
+        <p
+          className="mt-1 text-xs text-gray-500"
+          data-testid="stats-attribution"
+        >
+          Based on {data.post_count} reports since{" "}
+          {new Date(data.reporting_since).toLocaleDateString()}
         </p>
       )}
 
@@ -44,5 +57,5 @@ export function CommunityStats() {
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/components/heating-oil/HeatingOilDashboard.tsx
+++ b/frontend/components/heating-oil/HeatingOilDashboard.tsx
@@ -32,6 +32,9 @@ export function HeatingOilDashboard() {
   const trackedStates = data?.tracked_states || [];
   const nationalPrice = prices.find((p) => p.state === "US");
   const statePrices = prices.filter((p) => p.state !== "US");
+  const visiblePrices = statePrices.filter(
+    (p) => !selectedState || p.state === selectedState,
+  );
 
   return (
     <div className="space-y-6">
@@ -75,49 +78,56 @@ export function HeatingOilDashboard() {
         </select>
       </div>
 
+      {/* Empty state — no price data available for the current view */}
+      {visiblePrices.length === 0 && (
+        <div className="rounded-lg border bg-gray-50 p-6 text-center text-sm text-gray-500">
+          {prices.length === 0
+            ? "No heating oil price data is available right now. Please check back soon."
+            : `No heating oil price data for ${US_STATES[selectedState ?? ""] || selectedState}.`}
+        </div>
+      )}
+
       {/* State price cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {statePrices
-          .filter((p) => !selectedState || p.state === selectedState)
-          .map((p) => {
-            const diff = nationalPrice
-              ? ((p.price_per_gallon - nationalPrice.price_per_gallon) /
-                  nationalPrice.price_per_gallon) *
-                100
-              : null;
+        {visiblePrices.map((p) => {
+          const diff = nationalPrice
+            ? ((p.price_per_gallon - nationalPrice.price_per_gallon) /
+                nationalPrice.price_per_gallon) *
+              100
+            : null;
 
-            return (
-              <button
-                type="button"
-                key={p.state}
-                className="rounded-lg border p-4 text-left cursor-pointer hover:border-primary-300 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-                onClick={() => setSelectedState(p.state)}
-              >
-                <div className="flex items-center justify-between">
-                  <p className="font-semibold text-gray-900">
-                    {US_STATES[p.state] || p.state}
-                  </p>
-                  {diff !== null && (
-                    <span
-                      className={`text-xs font-medium ${
-                        diff < 0
-                          ? "text-success-600"
-                          : diff > 0
-                            ? "text-danger-600"
-                            : "text-gray-500"
-                      }`}
-                    >
-                      {diff > 0 ? "+" : ""}
-                      {diff.toFixed(1)}%
-                    </span>
-                  )}
-                </div>
-                <p className="text-lg font-bold text-gray-900">
-                  ${p.price_per_gallon.toFixed(2)}/gal
+          return (
+            <button
+              type="button"
+              key={p.state}
+              className="rounded-lg border p-4 text-left cursor-pointer hover:border-primary-300 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+              onClick={() => setSelectedState(p.state)}
+            >
+              <div className="flex items-center justify-between">
+                <p className="font-semibold text-gray-900">
+                  {US_STATES[p.state] || p.state}
                 </p>
-              </button>
-            );
-          })}
+                {diff !== null && (
+                  <span
+                    className={`text-xs font-medium ${
+                      diff < 0
+                        ? "text-success-600"
+                        : diff > 0
+                          ? "text-danger-600"
+                          : "text-gray-500"
+                    }`}
+                  >
+                    {diff > 0 ? "+" : ""}
+                    {diff.toFixed(1)}%
+                  </span>
+                )}
+              </div>
+              <p className="text-lg font-bold text-gray-900">
+                ${p.price_per_gallon.toFixed(2)}/gal
+              </p>
+            </button>
+          );
+        })}
       </div>
 
       {/* Detail sections when a state is selected */}

--- a/frontend/components/propane/PropaneDashboard.tsx
+++ b/frontend/components/propane/PropaneDashboard.tsx
@@ -32,6 +32,9 @@ export function PropaneDashboard() {
   const trackedStates = data?.tracked_states || [];
   const nationalPrice = prices.find((p) => p.state === "US");
   const statePrices = prices.filter((p) => p.state !== "US");
+  const visiblePrices = statePrices.filter(
+    (p) => !selectedState || p.state === selectedState,
+  );
 
   return (
     <div className="space-y-6">
@@ -75,49 +78,56 @@ export function PropaneDashboard() {
         </select>
       </div>
 
+      {/* Empty state — no price data available for the current view */}
+      {visiblePrices.length === 0 && (
+        <div className="rounded-lg border bg-gray-50 p-6 text-center text-sm text-gray-500">
+          {prices.length === 0
+            ? "No propane price data is available right now. Please check back soon."
+            : `No propane price data for ${US_STATES[selectedState ?? ""] || selectedState}.`}
+        </div>
+      )}
+
       {/* State price cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {statePrices
-          .filter((p) => !selectedState || p.state === selectedState)
-          .map((p) => {
-            const diff = nationalPrice
-              ? ((p.price_per_gallon - nationalPrice.price_per_gallon) /
-                  nationalPrice.price_per_gallon) *
-                100
-              : null;
+        {visiblePrices.map((p) => {
+          const diff = nationalPrice
+            ? ((p.price_per_gallon - nationalPrice.price_per_gallon) /
+                nationalPrice.price_per_gallon) *
+              100
+            : null;
 
-            return (
-              <button
-                type="button"
-                key={p.state}
-                className="rounded-lg border p-4 text-left cursor-pointer hover:border-primary-300 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-                onClick={() => setSelectedState(p.state)}
-              >
-                <div className="flex items-center justify-between">
-                  <p className="font-semibold text-gray-900">
-                    {US_STATES[p.state] || p.state}
-                  </p>
-                  {diff !== null && (
-                    <span
-                      className={`text-xs font-medium ${
-                        diff < 0
-                          ? "text-success-600"
-                          : diff > 0
-                            ? "text-danger-600"
-                            : "text-gray-500"
-                      }`}
-                    >
-                      {diff > 0 ? "+" : ""}
-                      {diff.toFixed(1)}%
-                    </span>
-                  )}
-                </div>
-                <p className="text-lg font-bold text-gray-900">
-                  ${p.price_per_gallon.toFixed(2)}/gal
+          return (
+            <button
+              type="button"
+              key={p.state}
+              className="rounded-lg border p-4 text-left cursor-pointer hover:border-primary-300 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+              onClick={() => setSelectedState(p.state)}
+            >
+              <div className="flex items-center justify-between">
+                <p className="font-semibold text-gray-900">
+                  {US_STATES[p.state] || p.state}
                 </p>
-              </button>
-            );
-          })}
+                {diff !== null && (
+                  <span
+                    className={`text-xs font-medium ${
+                      diff < 0
+                        ? "text-success-600"
+                        : diff > 0
+                          ? "text-danger-600"
+                          : "text-gray-500"
+                    }`}
+                  >
+                    {diff > 0 ? "+" : ""}
+                    {diff.toFixed(1)}%
+                  </span>
+                )}
+              </div>
+              <p className="text-lg font-bold text-gray-900">
+                ${p.price_per_gallon.toFixed(2)}/gal
+              </p>
+            </button>
+          );
+        })}
       </div>
 
       {/* Detail sections when a state is selected */}

--- a/frontend/components/water/WaterRateBenchmark.tsx
+++ b/frontend/components/water/WaterRateBenchmark.tsx
@@ -1,13 +1,13 @@
-'use client'
+"use client";
 
-import { useWaterBenchmark } from '@/lib/hooks/useWater'
+import { useWaterBenchmark } from "@/lib/hooks/useWater";
 
 interface WaterRateBenchmarkProps {
-  state: string
+  state: string;
 }
 
 export function WaterRateBenchmark({ state }: WaterRateBenchmarkProps) {
-  const { data, isLoading, error } = useWaterBenchmark(state)
+  const { data, isLoading, error } = useWaterBenchmark(state);
 
   if (isLoading) {
     return (
@@ -16,10 +16,19 @@ export function WaterRateBenchmark({ state }: WaterRateBenchmarkProps) {
           <div key={i} className="animate-pulse rounded-lg bg-gray-100 h-12" />
         ))}
       </div>
-    )
+    );
   }
 
-  if (error || !data) return null
+  if (error) {
+    return (
+      <div className="rounded-lg border border-warning-200 bg-warning-50 p-4 text-sm text-warning-800">
+        No water rate data is available for {state} yet. Check back as we add
+        more municipalities.
+      </div>
+    );
+  }
+
+  if (!data) return null;
 
   return (
     <div className="space-y-4">
@@ -32,45 +41,51 @@ export function WaterRateBenchmark({ state }: WaterRateBenchmarkProps) {
         <div className="rounded-lg border bg-cyan-50 p-4">
           <p className="text-sm font-medium text-cyan-700">Average Monthly</p>
           <p className="text-xl font-bold text-cyan-900">
-            ${data.avg_monthly_cost?.toFixed(2) ?? '—'}
+            ${data.avg_monthly_cost?.toFixed(2) ?? "—"}
           </p>
         </div>
         <div className="rounded-lg border bg-success-50 p-4">
           <p className="text-sm font-medium text-success-700">Lowest</p>
           <p className="text-xl font-bold text-success-900">
-            ${data.min_monthly_cost?.toFixed(2) ?? '—'}
+            ${data.min_monthly_cost?.toFixed(2) ?? "—"}
           </p>
         </div>
         <div className="rounded-lg border bg-danger-50 p-4">
           <p className="text-sm font-medium text-danger-700">Highest</p>
           <p className="text-xl font-bold text-danger-900">
-            ${data.max_monthly_cost?.toFixed(2) ?? '—'}
+            ${data.max_monthly_cost?.toFixed(2) ?? "—"}
           </p>
         </div>
       </div>
 
       <p className="text-xs text-gray-500">
-        Based on {data.usage_gallons.toLocaleString()} gallons/month typical household usage
-        across {data.municipalities} municipalities
+        Based on {data.usage_gallons.toLocaleString()} gallons/month typical
+        household usage across {data.municipalities} municipalities
       </p>
 
       {/* Municipality breakdown */}
       {data.rates.length > 0 && (
         <div className="rounded-lg border">
           <div className="border-b px-4 py-2 bg-gray-50">
-            <p className="text-sm font-medium text-gray-700">Municipality Comparison</p>
+            <p className="text-sm font-medium text-gray-700">
+              Municipality Comparison
+            </p>
           </div>
           <div className="divide-y">
             {data.rates.map((r) => {
-              const avgCost = data.avg_monthly_cost ?? 0
-              const diff = avgCost > 0
-                ? ((r.monthly_cost - avgCost) / avgCost) * 100
-                : 0
+              const avgCost = data.avg_monthly_cost ?? 0;
+              const diff =
+                avgCost > 0 ? ((r.monthly_cost - avgCost) / avgCost) * 100 : 0;
 
               return (
-                <div key={r.municipality} className="flex items-center justify-between px-4 py-3">
+                <div
+                  key={r.municipality}
+                  className="flex items-center justify-between px-4 py-3"
+                >
                   <div>
-                    <p className="font-medium text-gray-900">{r.municipality}</p>
+                    <p className="font-medium text-gray-900">
+                      {r.municipality}
+                    </p>
                     <p className="text-xs text-gray-500">
                       Base charge: ${r.base_charge.toFixed(2)}/mo
                     </p>
@@ -81,18 +96,23 @@ export function WaterRateBenchmark({ state }: WaterRateBenchmarkProps) {
                     </p>
                     <span
                       className={`text-xs font-medium ${
-                        diff < -2 ? 'text-success-600' : diff > 2 ? 'text-danger-600' : 'text-gray-500'
+                        diff < -2
+                          ? "text-success-600"
+                          : diff > 2
+                            ? "text-danger-600"
+                            : "text-gray-500"
                       }`}
                     >
-                      {diff > 0 ? '+' : ''}{diff.toFixed(1)}% vs avg
+                      {diff > 0 ? "+" : ""}
+                      {diff.toFixed(1)}% vs avg
                     </span>
                   </div>
                 </div>
-              )
+              );
             })}
           </div>
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/lib/api/__tests__/cca.test.ts
+++ b/frontend/lib/api/__tests__/cca.test.ts
@@ -62,6 +62,17 @@ describe("detectCCA", () => {
     expect(result.in_cca).toBe(false);
     expect(result.program).toBeNull();
   });
+
+  it("omits zip_code from the query when it is undefined (state-only detect)", async () => {
+    // Regression: an undefined zip must NOT be serialized as the literal
+    // string "undefined" (audit: GET /cca/detect?zip_code=undefined&state=CT).
+    mockFetch.mockResolvedValue(mockJson({ in_cca: false, program: null }));
+    await detectCCA({ zip_code: undefined, state: "CT" });
+    const url = mockFetch.mock.calls[0]![0] as string;
+    expect(url).toContain("state=CT");
+    expect(url).not.toContain("zip_code");
+    expect(url).not.toContain("undefined");
+  });
 });
 
 describe("compareCCARate", () => {

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -273,7 +273,12 @@ export const apiClient = {
     endpoint: string,
     params?: Record<
       string,
-      string | number | boolean | (string | number | boolean)[]
+      | string
+      | number
+      | boolean
+      | null
+      | undefined
+      | (string | number | boolean)[]
     >,
     options?: { signal?: AbortSignal },
   ): Promise<T> {
@@ -282,8 +287,12 @@ export const apiClient = {
     if (params && Object.keys(params).length > 0) {
       const searchParams = new URLSearchParams();
       for (const [k, v] of Object.entries(params)) {
+        // Skip nullish params so absent values are omitted from the query
+        // string rather than serialized as the literal "undefined"/"null".
+        if (v === undefined || v === null) continue;
         if (Array.isArray(v)) {
           for (const item of v) {
+            if (item === undefined || item === null) continue;
             searchParams.append(k, String(item));
           }
         } else {
@@ -291,7 +300,7 @@ export const apiClient = {
         }
       }
       const qs = searchParams.toString();
-      urlStr += `?${qs}`;
+      if (qs) urlStr += `?${qs}`;
     }
 
     return fetchWithRetry<T>(urlStr, {

--- a/frontend/lib/api/community.ts
+++ b/frontend/lib/api/community.ts
@@ -1,58 +1,59 @@
-import { apiClient } from './client'
+import { apiClient } from "./client";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export interface CommunityPost {
-  id: string
-  user_id: string
-  region: string
-  utility_type: string
-  post_type: string
-  title: string
-  body: string
-  rate_per_unit: number | null
-  rate_unit: string | null
-  supplier_name: string | null
-  is_hidden: boolean
-  is_pending_moderation: boolean
-  hidden_reason: string | null
-  upvote_count: number
-  created_at: string
-  updated_at: string
+  id: string;
+  user_id: string;
+  region: string;
+  utility_type: string;
+  post_type: string;
+  title: string;
+  body: string;
+  rate_per_unit: number | null;
+  rate_unit: string | null;
+  supplier_name: string | null;
+  is_hidden: boolean;
+  is_pending_moderation: boolean;
+  hidden_reason: string | null;
+  upvote_count: number;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface PostsResponse {
-  posts: CommunityPost[]
-  total: number
-  page: number
-  per_page: number
-  pages: number
+  posts: CommunityPost[];
+  total: number;
+  page: number;
+  per_page: number;
+  pages: number;
 }
 
 export interface CreatePostPayload {
-  title: string
-  body: string
-  utility_type: string
-  region: string
-  post_type: string
-  rate_per_unit?: number | null
-  rate_unit?: string | null
-  supplier_name?: string | null
+  title: string;
+  body: string;
+  utility_type: string;
+  region: string;
+  post_type: string;
+  rate_per_unit?: number | null;
+  rate_unit?: string | null;
+  supplier_name?: string | null;
 }
 
 export interface VoteResponse {
-  voted: boolean
-  upvote_count: number
+  voted: boolean;
+  upvote_count: number;
 }
 
 export interface CommunityStatsResponse {
-  user_count: number
-  post_count: number
-  avg_savings_pct: number | null
-  top_tip: CommunityPost | null
-  since: string | null
+  total_users: number;
+  post_count: number;
+  region: string;
+  avg_savings_pct: number | null;
+  top_tip: CommunityPost | null;
+  reporting_since: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,36 +67,52 @@ export async function fetchPosts(
   perPage = 20,
   signal?: AbortSignal,
 ): Promise<PostsResponse> {
-  return apiClient.get<PostsResponse>('/community/posts', {
-    region,
-    utility_type: utilityType,
-    page,
-    per_page: perPage,
-  }, { signal })
+  return apiClient.get<PostsResponse>(
+    "/community/posts",
+    {
+      region,
+      utility_type: utilityType,
+      page,
+      per_page: perPage,
+    },
+    { signal },
+  );
 }
 
-export async function createPost(data: CreatePostPayload): Promise<CommunityPost> {
-  return apiClient.post<CommunityPost>('/community/posts', data)
+export async function createPost(
+  data: CreatePostPayload,
+): Promise<CommunityPost> {
+  return apiClient.post<CommunityPost>("/community/posts", data);
 }
 
 export async function editPost(
   postId: string,
   data: { title?: string; body?: string; supplier_name?: string },
 ): Promise<CommunityPost> {
-  return apiClient.put<CommunityPost>(`/community/posts/${postId}`, data)
+  return apiClient.put<CommunityPost>(`/community/posts/${postId}`, data);
 }
 
 export async function toggleVote(postId: string): Promise<VoteResponse> {
-  return apiClient.post<VoteResponse>(`/community/posts/${postId}/vote`, {})
+  return apiClient.post<VoteResponse>(`/community/posts/${postId}/vote`, {});
 }
 
-export async function reportPost(postId: string, reason?: string): Promise<{ status: string }> {
-  return apiClient.post<{ status: string }>(`/community/posts/${postId}/report`, { reason })
+export async function reportPost(
+  postId: string,
+  reason?: string,
+): Promise<{ status: string }> {
+  return apiClient.post<{ status: string }>(
+    `/community/posts/${postId}/report`,
+    { reason },
+  );
 }
 
 export async function fetchCommunityStats(
   region: string,
   signal?: AbortSignal,
 ): Promise<CommunityStatsResponse> {
-  return apiClient.get<CommunityStatsResponse>('/community/stats', { region }, { signal })
+  return apiClient.get<CommunityStatsResponse>(
+    "/community/stats",
+    { region },
+    { signal },
+  );
 }

--- a/frontend/lib/api/suppliers.ts
+++ b/frontend/lib/api/suppliers.ts
@@ -2,8 +2,12 @@
  * Supplier API functions
  */
 
-import { apiClient } from './client'
-import type { Supplier, SupplierRecommendation, RawSupplierRecord } from '@/types'
+import { apiClient } from "./client";
+import type {
+  Supplier,
+  SupplierRecommendation,
+  RawSupplierRecord,
+} from "@/types";
 
 /**
  * Backend API response shape for a supplier record.
@@ -13,30 +17,31 @@ import type { Supplier, SupplierRecommendation, RawSupplierRecord } from '@/type
  * This is an alias for documentation purposes — RawSupplierRecord is the
  * broader type used by normalization mappers throughout the app.
  */
-export type SupplierApiRecord = RawSupplierRecord
+export type SupplierApiRecord = RawSupplierRecord;
 
 export interface GetSuppliersResponse {
-  suppliers: RawSupplierRecord[]
+  suppliers: RawSupplierRecord[];
   /** Pagination total count from the backend envelope */
-  total: number
-  page?: number
-  page_size?: number
+  total: number;
+  page?: number;
+  page_size?: number;
 }
 
 export interface GetRecommendationResponse {
-  recommendation: SupplierRecommendation
+  // Null when no per-supplier pricing exists to base a recommendation on.
+  recommendation: SupplierRecommendation | null;
 }
 
 export interface InitiateSwitchRequest {
-  newSupplierId: string
-  gdprConsent: boolean
-  currentSupplierId?: string
+  newSupplierId: string;
+  gdprConsent: boolean;
+  currentSupplierId?: string;
 }
 
 export interface InitiateSwitchResponse {
-  success: boolean
-  referenceNumber: string
-  estimatedCompletionDate: string
+  success: boolean;
+  referenceNumber: string;
+  estimatedCompletionDate: string;
 }
 
 /**
@@ -47,18 +52,23 @@ export async function getSuppliers(
   annualUsage?: number,
   signal?: AbortSignal,
 ): Promise<GetSuppliersResponse> {
-  const params: Record<string, string> = { region }
+  const params: Record<string, string> = { region };
   if (annualUsage) {
-    params.annual_usage = annualUsage.toString()
+    params.annual_usage = annualUsage.toString();
   }
-  return apiClient.get<GetSuppliersResponse>('/suppliers', params, { signal })
+  return apiClient.get<GetSuppliersResponse>("/suppliers", params, { signal });
 }
 
 /**
  * Get a specific supplier by ID
  */
-export async function getSupplier(supplierId: string, signal?: AbortSignal): Promise<Supplier> {
-  return apiClient.get<Supplier>(`/suppliers/${supplierId}`, undefined, { signal })
+export async function getSupplier(
+  supplierId: string,
+  signal?: AbortSignal,
+): Promise<Supplier> {
+  return apiClient.get<Supplier>(`/suppliers/${supplierId}`, undefined, {
+    signal,
+  });
 }
 
 /**
@@ -70,11 +80,15 @@ export async function getRecommendation(
   region: string,
   signal?: AbortSignal,
 ): Promise<GetRecommendationResponse> {
-  return apiClient.post<GetRecommendationResponse>('/suppliers/recommend', {
-    currentSupplierId,
-    annualUsage,
-    region,
-  }, { signal })
+  return apiClient.post<GetRecommendationResponse>(
+    "/suppliers/recommend",
+    {
+      currentSupplierId,
+      annualUsage,
+      region,
+    },
+    { signal },
+  );
 }
 
 /**
@@ -85,19 +99,23 @@ export async function compareSuppliers(
   annualUsage: number,
   signal?: AbortSignal,
 ): Promise<{ comparisons: Supplier[] }> {
-  return apiClient.post('/suppliers/compare', {
-    supplierIds,
-    annualUsage,
-  }, { signal })
+  return apiClient.post(
+    "/suppliers/compare",
+    {
+      supplierIds,
+      annualUsage,
+    },
+    { signal },
+  );
 }
 
 /**
  * Initiate a supplier switch
  */
 export async function initiateSwitch(
-  request: InitiateSwitchRequest
+  request: InitiateSwitchRequest,
 ): Promise<InitiateSwitchResponse> {
-  return apiClient.post<InitiateSwitchResponse>('/suppliers/switch', request)
+  return apiClient.post<InitiateSwitchResponse>("/suppliers/switch", request);
 }
 
 /**
@@ -107,11 +125,13 @@ export async function getSwitchStatus(
   referenceNumber: string,
   signal?: AbortSignal,
 ): Promise<{
-  status: 'pending' | 'processing' | 'completed' | 'failed'
-  estimatedCompletionDate: string
-  lastUpdated: string
+  status: "pending" | "processing" | "completed" | "failed";
+  estimatedCompletionDate: string;
+  lastUpdated: string;
 }> {
-  return apiClient.get(`/suppliers/switch/${referenceNumber}`, undefined, { signal })
+  return apiClient.get(`/suppliers/switch/${referenceNumber}`, undefined, {
+    signal,
+  });
 }
 
 // ============================================================================
@@ -119,85 +139,85 @@ export async function getSwitchStatus(
 // ============================================================================
 
 export interface UserSupplierResponse {
-  supplier_id: string
-  supplier_name: string
-  regions: string[]
-  rating: number | null
-  green_energy: boolean
-  website: string | null
+  supplier_id: string;
+  supplier_name: string;
+  regions: string[];
+  rating: number | null;
+  green_energy: boolean;
+  website: string | null;
 }
 
 export interface LinkAccountRequest {
-  supplier_id: string
-  account_number: string
-  meter_number?: string
-  service_zip?: string
-  account_nickname?: string
-  consent_given: boolean
+  supplier_id: string;
+  account_number: string;
+  meter_number?: string;
+  service_zip?: string;
+  account_nickname?: string;
+  consent_given: boolean;
 }
 
 export interface LinkedAccountResponse {
-  supplier_id: string
-  supplier_name: string
-  account_number_masked: string | null
-  meter_number_masked: string | null
-  service_zip: string | null
-  account_nickname: string | null
-  is_primary: boolean
-  verified_at: string | null
-  created_at: string
+  supplier_id: string;
+  supplier_name: string;
+  account_number_masked: string | null;
+  meter_number_masked: string | null;
+  service_zip: string | null;
+  account_nickname: string | null;
+  is_primary: boolean;
+  verified_at: string | null;
+  created_at: string;
 }
 
 /**
  * Set the authenticated user's current supplier
  */
 export async function setUserSupplier(
-  supplierId: string
+  supplierId: string,
 ): Promise<UserSupplierResponse> {
-  return apiClient.put<UserSupplierResponse>('/user/supplier', {
+  return apiClient.put<UserSupplierResponse>("/user/supplier", {
     supplier_id: supplierId,
-  })
+  });
 }
 
 /**
  * Get the authenticated user's current supplier
  */
 export async function getUserSupplier(signal?: AbortSignal): Promise<{
-  supplier: UserSupplierResponse | null
+  supplier: UserSupplierResponse | null;
 }> {
-  return apiClient.get('/user/supplier', undefined, { signal })
+  return apiClient.get("/user/supplier", undefined, { signal });
 }
 
 /**
  * Remove the authenticated user's current supplier
  */
 export async function removeUserSupplier(): Promise<{ message: string }> {
-  return apiClient.delete('/user/supplier')
+  return apiClient.delete("/user/supplier");
 }
 
 /**
  * Link a utility account to a supplier
  */
 export async function linkSupplierAccount(
-  data: LinkAccountRequest
+  data: LinkAccountRequest,
 ): Promise<LinkedAccountResponse> {
-  return apiClient.post<LinkedAccountResponse>('/user/supplier/link', data)
+  return apiClient.post<LinkedAccountResponse>("/user/supplier/link", data);
 }
 
 /**
  * Get all linked supplier accounts (masked)
  */
 export async function getUserSupplierAccounts(signal?: AbortSignal): Promise<{
-  accounts: LinkedAccountResponse[]
+  accounts: LinkedAccountResponse[];
 }> {
-  return apiClient.get('/user/supplier/accounts', undefined, { signal })
+  return apiClient.get("/user/supplier/accounts", undefined, { signal });
 }
 
 /**
  * Unlink a specific supplier account
  */
 export async function unlinkSupplierAccount(
-  supplierId: string
+  supplierId: string,
 ): Promise<{ message: string }> {
-  return apiClient.delete(`/user/supplier/accounts/${supplierId}`)
+  return apiClient.delete(`/user/supplier/accounts/${supplierId}`);
 }


### PR DESCRIPTION
Resolves the actionable findings from the 2026-05-21 browser audit of rateshift.app.

## Validation
- Backend: **4036 passed**, 10 integration skipped (no DATABASE_URL) — `pytest -m "not slow"`
- Frontend: **3439 passed**, 289 suites — full jest run
- Pre-push verification: passed

## Critical (broken functionality)
- **`/api/v1/forecast/electricity` → 500** and **`/api/v1/reports/optimization` → 500**: SQL compared the `utility_type` enum against uppercase literals (`'ELECTRICITY'`), but the Postgres enum stores lowercase (`'electricity'`), so Postgres raised `invalid input value for enum` as an unhandled 500. Fixed in `forecast_service.py`, `optimization_report_service.py`, and a **latent third instance** in `rate_export_service.py`. Existing tests masked the bug by feeding uppercase mock rows; corrected and added SQL-inspecting regression tests.
- **`POST /api/v1/suppliers/recommend` → 405**: the route didn't exist (POST fell through to `GET /{supplier_id}`). Added the handler.

## High (data / UX)
- **Suppliers all $0.00/kWh**: handler dropped the `annual_usage` param and the response model had no price fields. Now estimates `avg_price_per_kwh` from the regional electricity market rate (same source the dashboard uses) and computes `estimated_annual_cost`. ⚠️ **Known limitation:** the `tariffs` table is empty and unlinked from `supplier_registry`, so all suppliers share the regional rate — true per-supplier pricing needs tariff data seeded.
- **Heating-oil / propane blank pages**: no empty-state branch when the price list was empty. Added empty states.
- **Community "users in your area" blank**: frontend read `user_count`/`since`; backend sends `total_users`/`reporting_since`. Aligned keys and added `post_count` to the stats query.

## Medium / Low
- **`cca/detect?zip_code=undefined`**: `apiClient.get` serialized `undefined`/`null` params as literal strings. Now skips nullish params globally (fixes this and any future caller).
- **Water benchmark blank on error**: replaced a silent `return null` (ADR-011 violation) with an explicit empty state.

## Assessed as out of scope (not code bugs)
- 503s on RSC prefetch → Vercel edge cold-start/timeout (needs Vercel function logs)
- Dashboard $0 savings → expected for a fresh test account
- Microsoft Clarity JS error → third-party script

## Follow-ups
- Seed `tariffs` data (or relink to `supplier_registry`) for real per-supplier pricing
- Run the DSP graph update for the new repo method / endpoint / model fields (deferred to avoid colliding with automation on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)