### PR TITLE
feat: vendor-neutral supplier pricing (supplier_offers read model)

### DIFF
--- a/backend/api/v1/suppliers.py
+++ b/backend/api/v1/suppliers.py
@@ -21,11 +21,16 @@ from models.supplier import (
     SupplierResponse,
     TariffResponse,
 )
+from repositories.supplier_offer_repository import SupplierOfferRepository
 from repositories.supplier_repository import SupplierRegistryRepository
 
 logger = structlog.get_logger(__name__)
 
 router = APIRouter(tags=["Suppliers"])
+
+# Default annual consumption (kWh) for cost estimates when the caller omits
+# annual_usage — roughly the US residential average.
+DEFAULT_ANNUAL_USAGE_KWH = 10632
 
 # Regex for valid region codes (e.g. us_ct, uk, de, jp)
 _REGION_RE = re.compile(r"^[a-z]{2}(_[a-z]{2})?$")
@@ -110,11 +115,12 @@ async def list_suppliers(
     utility type, or green energy status. Data is sourced from the
     supplier_registry table. Results are cached in Redis for 1 hour.
 
-    Pricing (``avg_price_per_kwh`` / ``estimated_annual_cost``) is estimated
-    from the regional electricity market rate when ``region`` (and, for the
-    cost, ``annual_usage``) are supplied. There is no per-supplier tariff data
-    yet, so all suppliers share the regional rate — same approach as the
-    dashboard. Fields stay null when no market rate is available.
+    Pricing (``avg_price_per_kwh`` / ``estimated_annual_cost`` /
+    ``pricing_source`` / ``is_estimate``) comes from the vendor-neutral
+    ``supplier_offers`` read model. Today the only wired source is a regional
+    estimate (``is_estimate=true``); real per-supplier sources (state rate
+    boards, licensed APIs) drop in behind the same contract with no API change.
+    Fields stay null when no offer or rate is available.
     """
     repo = SupplierRegistryRepository(db, cache=redis)
     suppliers_data, total = await repo.list_suppliers(
@@ -128,18 +134,26 @@ async def list_suppliers(
 
     suppliers = [SupplierResponse(**s) for s in suppliers_data]
 
-    # Estimate pricing from the regional market rate (no per-supplier tariffs).
+    # Source-agnostic pricing: match each supplier to its cheapest offer.
     if region and suppliers:
         try:
-            market_rate = await repo.get_region_market_rate(region)
+            offer_repo = SupplierOfferRepository(db, cache=redis)
+            offers = await offer_repo.cheapest_available_by_supplier(
+                region, utility_type or "electricity"
+            )
         except Exception:
-            logger.warning("supplier_market_rate_lookup_failed", region=region, exc_info=True)
-            market_rate = None
-        if market_rate is not None:
-            est_cost = round(market_rate * annual_usage, 2) if annual_usage else None
-            for supplier in suppliers:
-                supplier.avg_price_per_kwh = market_rate
-                supplier.estimated_annual_cost = est_cost
+            logger.warning("supplier_offers_lookup_failed", region=region, exc_info=True)
+            offers = {}
+        for supplier in suppliers:
+            offer = offers.get(supplier.id) or offers.get(supplier.name)
+            if offer is None:
+                continue
+            supplier.avg_price_per_kwh = offer.rate_per_kwh
+            supplier.estimated_annual_cost = (
+                offer.annual_cost(annual_usage) if annual_usage else None
+            )
+            supplier.pricing_source = offer.source
+            supplier.is_estimate = offer.is_estimate
 
     return SuppliersResponse(
         suppliers=suppliers,
@@ -167,17 +181,52 @@ async def recommend_supplier(
 ):
     """Return a switching recommendation, or ``null`` when none can be computed.
 
-    Per-supplier tariff data does not exist yet (the ``tariffs`` table is empty
-    and not linked to ``supplier_registry``), so there is no basis for
-    supplier-specific savings — every supplier is priced at the same regional
-    market rate. We therefore return ``{"recommendation": null}`` (HTTP 200)
-    instead of fabricating a savings figure.
-
-    This route previously did not exist, so a POST fell through to
-    ``GET /{supplier_id}`` and returned 405. Defining it fixes the 405. When
-    real tariffs are seeded, compute and return the cheapest alternative here.
+    Driven by the vendor-neutral ``supplier_offers`` read model. A recommendation
+    is only produced from **real** offers (``is_estimate=false``) — estimates are
+    uniform regional figures and provide no basis for supplier-specific savings,
+    so when only estimates exist this returns ``{"recommendation": null}``
+    (HTTP 200). As real sources (rate boards, licensed APIs) are wired in, this
+    endpoint starts returning actionable recommendations with no code change.
     """
-    return {"recommendation": None}
+    if not body.region:
+        return {"recommendation": None}
+
+    offer_repo = SupplierOfferRepository(db, cache=redis)
+    offers = await offer_repo.cheapest_available_by_supplier(body.region)
+    real = {k: o for k, o in offers.items() if not o.is_estimate}
+    if not real:
+        return {"recommendation": None}
+
+    annual = body.annualUsage or DEFAULT_ANNUAL_USAGE_KWH
+    best_key, best = min(real.items(), key=lambda kv: kv[1].rate_per_kwh)
+
+    # Savings are only meaningful against a known current supplier's real offer.
+    current = real.get(body.currentSupplierId) if body.currentSupplierId else None
+    estimated_savings: float | None = None
+    if current is not None:
+        estimated_savings = round(current.annual_cost(annual) - best.annual_cost(annual), 2)
+        # Already on the cheapest (or current isn't beatable) — nothing to recommend.
+        if estimated_savings <= 0 or best_key == body.currentSupplierId:
+            return {"recommendation": None}
+
+    return {
+        "recommendation": {
+            "supplier": {
+                "id": best.supplier_id,
+                "name": best.supplier_name,
+                "avgPricePerKwh": best.rate_per_kwh,
+                "estimatedAnnualCost": best.annual_cost(annual),
+                "tariffType": best.tariff_type,
+                "greenEnergy": (best.renewable_pct or 0) >= 100,
+                "enrollUrl": best.enroll_url,
+            },
+            "estimatedSavings": estimated_savings,
+            "pricingSource": best.source,
+            "termMonths": best.intro_term_months,
+            "cancellationFee": best.cancellation_fee,
+            "expiresAt": best.expires_at.isoformat() if best.expires_at else None,
+        }
+    }
 
 
 @router.get("/registry", summary="List suppliers with API integration")

--- a/backend/migrations/069_supplier_offers.sql
+++ b/backend/migrations/069_supplier_offers.sql
@@ -1,0 +1,61 @@
+-- 069_supplier_offers.sql
+-- Vendor-neutral supplier pricing read model.
+--
+-- The /suppliers and /suppliers/recommend endpoints must show real, source-
+-- agnostic pricing without coupling to any single provider. supplier_offers is
+-- the canonical store that pluggable source adapters (regional_estimate,
+-- ct_rate_board, arcadia, energybot, manual) all write into in one normalized
+-- shape, and that the read path consumes without knowing the source.
+--
+-- This supersedes the legacy `tariffs` table (supplier-keyed, no region/
+-- provenance/lifecycle) which is left in place but DEPRECATED — do not add new
+-- writers to it.
+
+CREATE TABLE IF NOT EXISTS supplier_offers (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Where the offer applies.
+    region             TEXT          NOT NULL,                       -- e.g. 'us_ct'
+    zip_code           TEXT          NULL,                           -- optional finer grain (zip-keyed sources)
+    utility_type       utility_type  NOT NULL DEFAULT 'electricity',
+    utility_territory  TEXT          NULL,                           -- e.g. 'Eversource' / 'United Illuminating'
+
+    -- Who is offering. supplier_id is nullable: some offers' suppliers may not
+    -- be in supplier_registry. supplier_name is denormalized for display.
+    supplier_id        UUID          NULL REFERENCES supplier_registry(id) ON DELETE SET NULL,
+    supplier_name      TEXT          NOT NULL,
+
+    -- Rate structure (a single rate is insufficient — intro/variable/fees matter).
+    rate_per_kwh       NUMERIC(12, 6) NOT NULL CHECK (rate_per_kwh >= 0),
+    standing_charge    NUMERIC(12, 6) NOT NULL DEFAULT 0 CHECK (standing_charge >= 0),
+    tariff_type        TEXT          NOT NULL DEFAULT 'fixed',       -- fixed | variable | fixed_tiered
+    intro_term_months  INT           NULL,
+    post_intro_rate    NUMERIC(12, 6) NULL,
+    cancellation_fee   NUMERIC(12, 2) NULL,
+    enrollment_fee     NUMERIC(12, 2) NULL,
+    renewable_pct      INT           NULL,
+    enroll_url         TEXT          NULL,
+
+    -- Provenance + lifecycle.
+    source             TEXT          NOT NULL,                       -- 'regional_estimate'|'ct_rate_board'|'arcadia'|'energybot'|'manual'
+    source_ref         TEXT          NULL,                           -- external id from the source
+    is_estimate        BOOLEAN       NOT NULL DEFAULT FALSE,         -- true = derived/uniform, not an obtainable offer
+    is_available       BOOLEAN       NOT NULL DEFAULT TRUE,
+    effective_date     DATE          NULL,
+    expires_at         DATE          NULL,
+    fetched_at         TIMESTAMPTZ   NOT NULL DEFAULT now(),
+    raw                JSONB         NULL
+);
+
+-- Primary read pattern: cheapest available per region/utility.
+CREATE INDEX IF NOT EXISTS idx_offers_region_util
+    ON supplier_offers (region, utility_type, is_available);
+
+-- Lookups by supplier (recommendation: current vs alternatives).
+CREATE INDEX IF NOT EXISTS idx_offers_supplier
+    ON supplier_offers (supplier_id);
+
+-- Idempotent upserts from sources that carry a stable external id.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_offers_source_ref
+    ON supplier_offers (source, source_ref, region)
+    WHERE source_ref IS NOT NULL;

--- a/backend/models/supplier.py
+++ b/backend/models/supplier.py
@@ -175,13 +175,15 @@ class SupplierResponse(BaseModel):
     rating: float | None = None
     green_energy_provider: bool
     is_active: bool
-    # Estimated pricing. There is no per-supplier tariff data yet (the tariffs
-    # table is empty and unlinked from supplier_registry), so these are derived
-    # from the regional electricity market rate — the same source the dashboard
-    # uses — rather than a per-supplier contract. Null when no market rate or
-    # annual usage is available.
+    # Pricing comes from the vendor-neutral supplier_offers read model via a
+    # pluggable source. ``pricing_source`` names that source (e.g.
+    # 'regional_estimate', 'ct_rate_board', 'arcadia') and ``is_estimate``
+    # flags a derived/uniform figure vs. an actually obtainable offer so the UI
+    # can label it. Null when no rate is available.
     avg_price_per_kwh: float | None = None
     estimated_annual_cost: float | None = None
+    pricing_source: str | None = None
+    is_estimate: bool = False
 
 
 class SupplierDetailResponse(BaseModel):

--- a/backend/models/supplier_offer.py
+++ b/backend/models/supplier_offer.py
@@ -1,0 +1,52 @@
+"""
+SupplierOffer — normalized, source-agnostic supplier pricing.
+
+Every pricing source adapter (regional_estimate, ct_rate_board, arcadia,
+energybot, manual) produces SupplierOffer instances in this one shape. The read
+path (/suppliers, /suppliers/recommend) consumes them without knowing the
+source. ``is_estimate`` distinguishes a derived/uniform figure from an actually
+obtainable offer so the UI can label it honestly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+
+@dataclass
+class SupplierOffer:
+    """One supplier pricing record, normalized across sources."""
+
+    supplier_name: str
+    rate_per_kwh: float
+    source: str  # 'regional_estimate' | 'ct_rate_board' | 'arcadia' | 'energybot' | 'manual'
+
+    # Defaults
+    region: str | None = None
+    zip_code: str | None = None
+    utility_type: str = "electricity"
+    utility_territory: str | None = None
+    supplier_id: str | None = None
+    standing_charge: float = 0.0
+    tariff_type: str = "fixed"
+    intro_term_months: int | None = None
+    post_intro_rate: float | None = None
+    cancellation_fee: float | None = None
+    enrollment_fee: float | None = None
+    renewable_pct: int | None = None
+    enroll_url: str | None = None
+    source_ref: str | None = None
+    is_estimate: bool = False
+    is_available: bool = True
+    effective_date: date | None = None
+    expires_at: date | None = None
+    raw: dict[str, Any] | None = field(default=None, repr=False)
+
+    def annual_cost(self, annual_usage_kwh: float) -> float:
+        """Estimated annual cost for a given usage, rounded to cents.
+
+        Uses standing_charge as an annualized fixed component when present.
+        """
+        return round(self.rate_per_kwh * annual_usage_kwh + (self.standing_charge or 0.0), 2)

--- a/backend/repositories/supplier_offer_repository.py
+++ b/backend/repositories/supplier_offer_repository.py
@@ -1,0 +1,176 @@
+"""
+SupplierOfferRepository — source-agnostic read/write for supplier_offers.
+
+The read path returns normalized ``SupplierOffer`` objects regardless of which
+source produced them. When no real (non-estimate) offers exist for a region it
+falls back to a live regional estimate (computed, not persisted), so callers
+always get a usable, clearly-labeled answer without showing stale data.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.supplier_offer import SupplierOffer
+from services.pricing.base import SupplierOfferSource
+from services.pricing.regional_estimate import RegionalEstimateSource
+
+logger = structlog.get_logger(__name__)
+
+# How fresh a persisted offer must be to be served as "current".
+DEFAULT_MAX_AGE_DAYS = 14
+
+_SELECT_COLS = (
+    "supplier_id, supplier_name, rate_per_kwh, standing_charge, tariff_type, "
+    "intro_term_months, post_intro_rate, cancellation_fee, enrollment_fee, "
+    "renewable_pct, enroll_url, source, source_ref, is_estimate, "
+    "effective_date, expires_at"
+)
+
+
+def _row_to_offer(row: Any, region: str, utility_type: str) -> SupplierOffer:
+    return SupplierOffer(
+        supplier_name=row["supplier_name"],
+        supplier_id=str(row["supplier_id"]) if row["supplier_id"] else None,
+        rate_per_kwh=float(row["rate_per_kwh"]),
+        standing_charge=float(row["standing_charge"] or 0),
+        tariff_type=row["tariff_type"],
+        intro_term_months=row["intro_term_months"],
+        post_intro_rate=(
+            float(row["post_intro_rate"]) if row["post_intro_rate"] is not None else None
+        ),
+        cancellation_fee=(
+            float(row["cancellation_fee"]) if row["cancellation_fee"] is not None else None
+        ),
+        enrollment_fee=(
+            float(row["enrollment_fee"]) if row["enrollment_fee"] is not None else None
+        ),
+        renewable_pct=row["renewable_pct"],
+        enroll_url=row["enroll_url"],
+        source=row["source"],
+        source_ref=row["source_ref"],
+        is_estimate=row["is_estimate"],
+        effective_date=row["effective_date"],
+        expires_at=row["expires_at"],
+        region=region,
+        utility_type=utility_type,
+    )
+
+
+class SupplierOfferRepository:
+    def __init__(
+        self,
+        db: AsyncSession,
+        cache: Any = None,
+        estimate_source: SupplierOfferSource | None = None,
+    ):
+        self._db = db
+        self._estimate = estimate_source or RegionalEstimateSource(db, cache=cache)
+
+    async def cheapest_available_by_supplier(
+        self,
+        region: str,
+        utility_type: str = "electricity",
+        *,
+        max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+    ) -> dict[str, SupplierOffer]:
+        """Cheapest *available, non-expired, fresh, real* offer per supplier.
+
+        Keyed by supplier_id (falling back to supplier_name). When there are no
+        such real offers, returns a live regional estimate instead — never
+        stale persisted data.
+        """
+        result = await self._db.execute(
+            text(
+                f"SELECT {_SELECT_COLS} FROM supplier_offers "
+                "WHERE region = :region AND utility_type = :ut "
+                "AND is_available = TRUE AND is_estimate = FALSE "
+                "AND (expires_at IS NULL OR expires_at >= CURRENT_DATE) "
+                "AND fetched_at >= now() - make_interval(days => :max_age) "
+                "ORDER BY rate_per_kwh ASC"
+            ),
+            {"region": region, "ut": utility_type, "max_age": max_age_days},
+        )
+        rows = result.mappings().all()
+
+        offers: dict[str, SupplierOffer] = {}
+        for row in rows:
+            offer = _row_to_offer(row, region, utility_type)
+            key = offer.supplier_id or offer.supplier_name
+            # rows are sorted by rate ASC, so the first seen per key is cheapest
+            offers.setdefault(key, offer)
+
+        if offers:
+            return offers
+
+        # No real offers — fall back to a live, labeled estimate.
+        estimates = await self._estimate.fetch(region)
+        return {
+            (o.supplier_id or o.supplier_name): o
+            for o in estimates
+            if o.utility_type == utility_type
+        }
+
+    async def upsert_offers(self, offers: list[SupplierOffer], *, source: str) -> int:
+        """Replace a source's offers for the regions it touched (idempotent).
+
+        Real source adapters call this from their sync jobs. Estimates are never
+        persisted. Deletes prior rows for ``(source, region)`` then inserts the
+        fresh set, so re-running a sync can't accumulate duplicates or leave
+        withdrawn offers behind.
+        """
+        persistable = [o for o in offers if not o.is_estimate]
+        regions = {o.region for o in persistable if o.region}
+        if not persistable:
+            return 0
+
+        for region in regions:
+            await self._db.execute(
+                text("DELETE FROM supplier_offers WHERE source = :source AND region = :region"),
+                {"source": source, "region": region},
+            )
+
+        for o in persistable:
+            await self._db.execute(
+                text(
+                    "INSERT INTO supplier_offers ("
+                    "region, zip_code, utility_type, utility_territory, supplier_id, "
+                    "supplier_name, rate_per_kwh, standing_charge, tariff_type, "
+                    "intro_term_months, post_intro_rate, cancellation_fee, enrollment_fee, "
+                    "renewable_pct, enroll_url, source, source_ref, is_estimate, "
+                    "is_available, effective_date, expires_at, fetched_at) VALUES ("
+                    ":region, :zip_code, :utility_type, :utility_territory, :supplier_id, "
+                    ":supplier_name, :rate_per_kwh, :standing_charge, :tariff_type, "
+                    ":intro_term_months, :post_intro_rate, :cancellation_fee, :enrollment_fee, "
+                    ":renewable_pct, :enroll_url, :source, :source_ref, FALSE, "
+                    ":is_available, :effective_date, :expires_at, now())"
+                ),
+                {
+                    "region": o.region,
+                    "zip_code": o.zip_code,
+                    "utility_type": o.utility_type,
+                    "utility_territory": o.utility_territory,
+                    "supplier_id": o.supplier_id,
+                    "supplier_name": o.supplier_name,
+                    "rate_per_kwh": o.rate_per_kwh,
+                    "standing_charge": o.standing_charge,
+                    "tariff_type": o.tariff_type,
+                    "intro_term_months": o.intro_term_months,
+                    "post_intro_rate": o.post_intro_rate,
+                    "cancellation_fee": o.cancellation_fee,
+                    "enrollment_fee": o.enrollment_fee,
+                    "renewable_pct": o.renewable_pct,
+                    "enroll_url": o.enroll_url,
+                    "source": source,
+                    "source_ref": o.source_ref,
+                    "is_available": o.is_available,
+                    "effective_date": o.effective_date,
+                    "expires_at": o.expires_at,
+                },
+            )
+        await self._db.commit()
+        return len(persistable)

--- a/backend/services/pricing/__init__.py
+++ b/backend/services/pricing/__init__.py
@@ -1,0 +1,13 @@
+"""Vendor-neutral supplier pricing sources.
+
+Each adapter implements ``SupplierOfferSource`` and produces normalized
+``SupplierOffer`` objects. The read path (repositories.supplier_offer_repository)
+consumes offers without knowing which source produced them, so sources can be
+added/swapped (regional_estimate, ct_rate_board, arcadia, energybot, manual)
+with no change to the API or frontend.
+"""
+
+from services.pricing.base import SupplierOfferSource
+from services.pricing.regional_estimate import RegionalEstimateSource
+
+__all__ = ["SupplierOfferSource", "RegionalEstimateSource"]

--- a/backend/services/pricing/base.py
+++ b/backend/services/pricing/base.py
@@ -1,0 +1,27 @@
+"""SupplierOfferSource protocol — the contract every pricing source implements."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from models.supplier_offer import SupplierOffer
+
+
+@runtime_checkable
+class SupplierOfferSource(Protocol):
+    """A pluggable supplier-pricing source.
+
+    Implementations must be side-effect free in ``fetch`` (no DB writes) — the
+    repository owns persistence. ``name`` is the value written to
+    ``supplier_offers.source``.
+    """
+
+    name: str
+
+    def covers(self, region: str) -> bool:
+        """Whether this source can provide offers for the given region."""
+        ...
+
+    async def fetch(self, region: str, *, zip_code: str | None = None) -> list[SupplierOffer]:
+        """Return current offers for the region (and optional zip)."""
+        ...

--- a/backend/services/pricing/regional_estimate.py
+++ b/backend/services/pricing/regional_estimate.py
@@ -1,0 +1,69 @@
+"""RegionalEstimateSource — the universal fallback pricing source.
+
+There is no per-supplier tariff data yet, so this derives an *estimate* from the
+regional electricity market rate (the same figure the dashboard uses) and
+applies it to every active supplier in the region. Offers are flagged
+``is_estimate=True`` so the UI labels them honestly and the recommendation
+engine never treats them as an actionable switch basis.
+
+This source is computed live (never persisted) so it can't go stale — the
+repository invokes it only when no real offers exist for a region.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.supplier_offer import SupplierOffer
+from repositories.supplier_repository import SupplierRegistryRepository
+
+logger = structlog.get_logger(__name__)
+
+
+class RegionalEstimateSource:
+    """Estimate every active supplier at the regional market rate."""
+
+    name = "regional_estimate"
+
+    def __init__(self, db: AsyncSession, cache: Any = None):
+        self._db = db
+        self._cache = cache
+
+    def covers(self, region: str) -> bool:  # noqa: ARG002 — interface signature
+        # Universal fallback — applies wherever a regional rate exists.
+        return True
+
+    async def fetch(
+        self,
+        region: str,
+        *,
+        zip_code: str | None = None,  # noqa: ARG002 — interface signature
+    ) -> list[SupplierOffer]:
+        repo = SupplierRegistryRepository(self._db, cache=self._cache)
+        rate = await repo.get_region_market_rate(region)
+        if rate is None:
+            logger.info("regional_estimate_no_rate", region=region)
+            return []
+
+        suppliers, _ = await repo.list_suppliers(
+            region=region,
+            utility_type="electricity",
+            active_only=True,
+            page=1,
+            page_size=100,
+        )
+        return [
+            SupplierOffer(
+                supplier_name=s["name"],
+                supplier_id=s["id"],
+                rate_per_kwh=rate,
+                region=region,
+                utility_type="electricity",
+                source=self.name,
+                is_estimate=True,
+            )
+            for s in suppliers
+        ]

--- a/backend/tests/test_api_suppliers.py
+++ b/backend/tests/test_api_suppliers.py
@@ -14,6 +14,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.dependencies import get_db_session, get_redis
+from models.supplier_offer import SupplierOffer
+
+_OFFER_REPO = (
+    "repositories.supplier_offer_repository.SupplierOfferRepository.cheapest_available_by_supplier"
+)
 
 _BASE = "/api/v1/suppliers"
 
@@ -155,59 +160,148 @@ class TestRecommendEndpoint:
     def test_post_recommend_returns_200_not_405(self, client):
         """Regression: the route exists, so POST is no longer 405 (it used to
         fall through to GET /{supplier_id})."""
-        resp = client.post(
-            f"{_BASE}/recommend",
-            json={
-                "currentSupplierId": "sup-001",
-                "annualUsage": 10500,
-                "region": "us_ct",
-            },
-        )
+        with patch(_OFFER_REPO, new=AsyncMock(return_value={})):
+            resp = client.post(
+                f"{_BASE}/recommend",
+                json={
+                    "currentSupplierId": "sup-001",
+                    "annualUsage": 10500,
+                    "region": "us_ct",
+                },
+            )
         assert resp.status_code == 200
         assert "recommendation" in resp.json()
 
     def test_post_recommend_accepts_empty_body(self, client):
         resp = client.post(f"{_BASE}/recommend", json={})
         assert resp.status_code == 200
+        assert resp.json()["recommendation"] is None
+
+    def test_null_when_only_estimates(self, client):
+        """Estimates are not an actionable switch basis → recommendation is null."""
+        offers = {
+            "sup-001": SupplierOffer(
+                supplier_name="Eversource",
+                supplier_id="sup-001",
+                rate_per_kwh=0.30,
+                source="regional_estimate",
+                is_estimate=True,
+            ),
+            "sup-002": SupplierOffer(
+                supplier_name="Cheap Co",
+                supplier_id="sup-002",
+                rate_per_kwh=0.20,
+                source="regional_estimate",
+                is_estimate=True,
+            ),
+        }
+        with patch(_OFFER_REPO, new=AsyncMock(return_value=offers)):
+            resp = client.post(
+                f"{_BASE}/recommend",
+                json={"currentSupplierId": "sup-001", "region": "us_ct"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["recommendation"] is None
+
+    def test_recommendation_from_real_offers(self, client):
+        """A cheaper real offer than the current supplier yields a recommendation."""
+        offers = {
+            "sup-001": SupplierOffer(
+                supplier_name="Eversource",
+                supplier_id="sup-001",
+                rate_per_kwh=0.30,
+                source="ct_rate_board",
+                is_estimate=False,
+            ),
+            "sup-002": SupplierOffer(
+                supplier_name="Cheap Co",
+                supplier_id="sup-002",
+                rate_per_kwh=0.20,
+                source="ct_rate_board",
+                is_estimate=False,
+                enroll_url="https://cheap.example/enroll",
+            ),
+        }
+        with patch(_OFFER_REPO, new=AsyncMock(return_value=offers)):
+            resp = client.post(
+                f"{_BASE}/recommend",
+                json={
+                    "currentSupplierId": "sup-001",
+                    "annualUsage": 10000,
+                    "region": "us_ct",
+                },
+            )
+        assert resp.status_code == 200
+        rec = resp.json()["recommendation"]
+        assert rec is not None
+        assert rec["supplier"]["name"] == "Cheap Co"
+        # (0.30 - 0.20) * 10000 = 1000.0
+        assert rec["estimatedSavings"] == 1000.0
+        assert rec["pricingSource"] == "ct_rate_board"
+        assert rec["supplier"]["enrollUrl"] == "https://cheap.example/enroll"
+
+    def test_null_when_current_already_cheapest(self, client):
+        offers = {
+            "sup-002": SupplierOffer(
+                supplier_name="Cheap Co",
+                supplier_id="sup-002",
+                rate_per_kwh=0.20,
+                source="ct_rate_board",
+                is_estimate=False,
+            ),
+        }
+        with patch(_OFFER_REPO, new=AsyncMock(return_value=offers)):
+            resp = client.post(
+                f"{_BASE}/recommend",
+                json={"currentSupplierId": "sup-002", "region": "us_ct"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["recommendation"] is None
 
 
 # ---------------------------------------------------------------------------
-# GET /suppliers/ estimated pricing  (audit 2026-05-21: all prices were $0.00)
+# GET /suppliers/ pricing via supplier_offers (audit 2026-05-21: prices were $0.00)
 # ---------------------------------------------------------------------------
 
 
-class TestEstimatedPricing:
-    def test_annual_usage_param_accepted_and_cost_estimated(self, client):
+class TestSupplierPricing:
+    def test_offer_pricing_applied_with_source_and_estimate_flag(self, client):
+        offers = {
+            "sup-001": SupplierOffer(
+                supplier_name="Eversource",
+                supplier_id="sup-001",
+                rate_per_kwh=0.25,
+                source="regional_estimate",
+                is_estimate=True,
+            )
+        }
         with (
             patch(
                 "repositories.supplier_repository.SupplierRegistryRepository.list_suppliers",
                 new=AsyncMock(return_value=([dict(_SUPPLIER_ROW)], 1)),
             ),
-            patch(
-                "repositories.supplier_repository.SupplierRegistryRepository.get_region_market_rate",
-                new=AsyncMock(return_value=0.25),
-            ),
+            patch(_OFFER_REPO, new=AsyncMock(return_value=offers)),
         ):
             resp = client.get(f"{_BASE}/?region=us_ct&annual_usage=10500")
         assert resp.status_code == 200
         supplier = resp.json()["suppliers"][0]
         assert supplier["avg_price_per_kwh"] == 0.25
-        # 0.25 * 10500 = 2625.0 — no longer the $0.00 the audit observed.
-        assert supplier["estimated_annual_cost"] == 2625.0
+        assert supplier["estimated_annual_cost"] == 2625.0  # 0.25 * 10500
+        assert supplier["pricing_source"] == "regional_estimate"
+        assert supplier["is_estimate"] is True
 
-    def test_price_null_when_no_market_rate(self, client):
+    def test_price_null_when_no_offer(self, client):
         with (
             patch(
                 "repositories.supplier_repository.SupplierRegistryRepository.list_suppliers",
                 new=AsyncMock(return_value=([dict(_SUPPLIER_ROW)], 1)),
             ),
-            patch(
-                "repositories.supplier_repository.SupplierRegistryRepository.get_region_market_rate",
-                new=AsyncMock(return_value=None),
-            ),
+            patch(_OFFER_REPO, new=AsyncMock(return_value={})),
         ):
             resp = client.get(f"{_BASE}/?region=us_ct&annual_usage=10500")
         assert resp.status_code == 200
         supplier = resp.json()["suppliers"][0]
         assert supplier["avg_price_per_kwh"] is None
         assert supplier["estimated_annual_cost"] is None
+        assert supplier["pricing_source"] is None
+        assert supplier["is_estimate"] is False

--- a/backend/tests/test_supplier_offer_repository.py
+++ b/backend/tests/test_supplier_offer_repository.py
@@ -1,0 +1,168 @@
+"""Tests for the vendor-neutral supplier_offers read/write layer."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.supplier_offer import SupplierOffer
+from repositories.supplier_offer_repository import SupplierOfferRepository
+from services.pricing.regional_estimate import RegionalEstimateSource
+
+
+def _rows_result(rows):
+    result = MagicMock()
+    result.mappings.return_value.all.return_value = rows
+    return result
+
+
+def _offer_row(**over):
+    base = {
+        "supplier_id": None,
+        "supplier_name": "Acme",
+        "rate_per_kwh": 0.20,
+        "standing_charge": 0,
+        "tariff_type": "fixed",
+        "intro_term_months": None,
+        "post_intro_rate": None,
+        "cancellation_fee": None,
+        "enrollment_fee": None,
+        "renewable_pct": None,
+        "enroll_url": None,
+        "source": "ct_rate_board",
+        "source_ref": None,
+        "is_estimate": False,
+        "effective_date": None,
+        "expires_at": None,
+    }
+    base.update(over)
+    return base
+
+
+class TestCheapestAvailableBySupplier:
+    async def test_keeps_cheapest_per_supplier(self):
+        # Sorted by rate ASC (as the SQL guarantees); two rows for sup-1.
+        rows = [
+            _offer_row(supplier_id="sup-1", supplier_name="A", rate_per_kwh=0.18),
+            _offer_row(supplier_id="sup-1", supplier_name="A", rate_per_kwh=0.22),
+            _offer_row(supplier_id="sup-2", supplier_name="B", rate_per_kwh=0.20),
+        ]
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_rows_result(rows))
+        estimate = MagicMock()
+        estimate.fetch = AsyncMock(return_value=[])  # must NOT be used
+
+        repo = SupplierOfferRepository(db, estimate_source=estimate)
+        offers = await repo.cheapest_available_by_supplier("us_ct")
+
+        assert set(offers) == {"sup-1", "sup-2"}
+        assert offers["sup-1"].rate_per_kwh == 0.18  # cheapest of the two
+        estimate.fetch.assert_not_called()
+
+    async def test_falls_back_to_estimate_when_no_real_offers(self):
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_rows_result([]))
+        est = SupplierOffer(
+            supplier_name="A",
+            supplier_id="sup-1",
+            rate_per_kwh=0.25,
+            source="regional_estimate",
+            is_estimate=True,
+            utility_type="electricity",
+        )
+        estimate = MagicMock()
+        estimate.fetch = AsyncMock(return_value=[est])
+
+        repo = SupplierOfferRepository(db, estimate_source=estimate)
+        offers = await repo.cheapest_available_by_supplier("us_ct")
+
+        estimate.fetch.assert_awaited_once_with("us_ct")
+        assert offers["sup-1"].is_estimate is True
+
+
+class TestUpsertOffers:
+    async def test_persists_real_offers_skips_estimates(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.commit = AsyncMock()
+        repo = SupplierOfferRepository(db, estimate_source=MagicMock())
+
+        offers = [
+            SupplierOffer(
+                supplier_name="A",
+                rate_per_kwh=0.2,
+                source="ct_rate_board",
+                region="us_ct",
+                is_estimate=False,
+            ),
+            SupplierOffer(
+                supplier_name="B",
+                rate_per_kwh=0.3,
+                source="ct_rate_board",
+                region="us_ct",
+                is_estimate=True,  # estimate — must be skipped
+            ),
+        ]
+        n = await repo.upsert_offers(offers, source="ct_rate_board")
+
+        assert n == 1  # only the real offer persisted
+        db.commit.assert_awaited_once()
+        # 1 DELETE (per region) + 1 INSERT
+        assert db.execute.await_count == 2
+
+    async def test_no_real_offers_is_noop(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.commit = AsyncMock()
+        repo = SupplierOfferRepository(db, estimate_source=MagicMock())
+        n = await repo.upsert_offers(
+            [
+                SupplierOffer(
+                    supplier_name="A",
+                    rate_per_kwh=0.2,
+                    source="regional_estimate",
+                    region="us_ct",
+                    is_estimate=True,
+                )
+            ],
+            source="regional_estimate",
+        )
+        assert n == 0
+        db.execute.assert_not_called()
+
+
+class TestRegionalEstimateSource:
+    async def test_one_estimate_per_active_supplier(self):
+        src = RegionalEstimateSource(MagicMock())
+        with (
+            pytest.MonkeyPatch.context() as mp,
+        ):
+            mp.setattr(
+                "repositories.supplier_repository.SupplierRegistryRepository.get_region_market_rate",
+                AsyncMock(return_value=0.27),
+            )
+            mp.setattr(
+                "repositories.supplier_repository.SupplierRegistryRepository.list_suppliers",
+                AsyncMock(
+                    return_value=(
+                        [{"id": "s1", "name": "Eversource"}, {"id": "s2", "name": "UI"}],
+                        2,
+                    )
+                ),
+            )
+            offers = await src.fetch("us_ct")
+
+        assert len(offers) == 2
+        assert all(o.is_estimate and o.rate_per_kwh == 0.27 for o in offers)
+        assert {o.supplier_name for o in offers} == {"Eversource", "UI"}
+
+    async def test_empty_when_no_market_rate(self):
+        src = RegionalEstimateSource(MagicMock())
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "repositories.supplier_repository.SupplierRegistryRepository.get_region_market_rate",
+                AsyncMock(return_value=None),
+            )
+            offers = await src.fetch("us_ct")
+        assert offers == []

--- a/frontend/__tests__/components/suppliers/SupplierCard.test.tsx
+++ b/frontend/__tests__/components/suppliers/SupplierCard.test.tsx
@@ -99,4 +99,22 @@ describe("SupplierCard", () => {
     fireEvent.click(screen.getByRole("button", { name: /switch to/i }));
     expect(onSelect).toHaveBeenCalledWith(baseSupplier);
   });
+
+  it("shows an Estimated badge when the price is an estimate", () => {
+    render(
+      <SupplierCard
+        supplier={{ ...baseSupplier, isEstimate: true } as unknown as Supplier}
+      />,
+    );
+    expect(screen.getByTestId("estimate-badge")).toBeInTheDocument();
+  });
+
+  it("hides the Estimated badge for a real offer", () => {
+    render(
+      <SupplierCard
+        supplier={{ ...baseSupplier, isEstimate: false } as unknown as Supplier}
+      />,
+    );
+    expect(screen.queryByTestId("estimate-badge")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/components/suppliers/SupplierCard.tsx
+++ b/frontend/components/suppliers/SupplierCard.tsx
@@ -1,183 +1,198 @@
-'use client'
+"use client";
 
-import React from 'react'
-import Image from 'next/image'
-import { cn } from '@/lib/utils/cn'
-import { formatCurrency } from '@/lib/utils/format'
-import { Card } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Star, Leaf, Zap, Check } from 'lucide-react'
-import type { Supplier } from '@/types'
+import React from "react";
+import Image from "next/image";
+import { cn } from "@/lib/utils/cn";
+import { formatCurrency } from "@/lib/utils/format";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Star, Leaf, Zap, Check } from "lucide-react";
+import type { Supplier } from "@/types";
 
 export interface SupplierCardProps {
-  supplier: Supplier
-  isCurrent?: boolean
-  currentAnnualCost?: number
-  showDetails?: boolean
-  onSelect?: (supplier: Supplier) => void
-  className?: string
+  supplier: Supplier;
+  isCurrent?: boolean;
+  currentAnnualCost?: number;
+  showDetails?: boolean;
+  onSelect?: (supplier: Supplier) => void;
+  className?: string;
 }
 
-export const SupplierCard: React.FC<SupplierCardProps> = React.memo(({
-  supplier,
-  isCurrent = false,
-  currentAnnualCost,
-  showDetails = false,
-  onSelect,
-  className,
-}) => {
-  const savings =
-    currentAnnualCost && currentAnnualCost > supplier.estimatedAnnualCost
-      ? currentAnnualCost - supplier.estimatedAnnualCost
-      : 0
+export const SupplierCard: React.FC<SupplierCardProps> = React.memo(
+  ({
+    supplier,
+    isCurrent = false,
+    currentAnnualCost,
+    showDetails = false,
+    onSelect,
+    className,
+  }) => {
+    const savings =
+      currentAnnualCost && currentAnnualCost > supplier.estimatedAnnualCost
+        ? currentAnnualCost - supplier.estimatedAnnualCost
+        : 0;
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      onSelect?.(supplier)
-    }
-  }
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onSelect?.(supplier);
+      }
+    };
 
-  return (
-    <Card
-      className={cn(
-        'transition-shadow hover:shadow-md',
-        isCurrent && 'ring-2 ring-primary-500',
-        className
-      )}
-      data-testid={`supplier-card-${supplier.id}`}
-    >
-      {/* Header with logo and name */}
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-3">
-          {supplier.logo ? (
-            <Image
-              src={supplier.logo}
-              alt={`${supplier.name} logo`}
-              width={48}
-              height={48}
-              className="rounded-lg object-contain"
-            />
-          ) : (
-            <div
-              data-testid="supplier-logo-placeholder"
-              className="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100"
-            >
-              <Zap className="h-6 w-6 text-gray-400" />
-            </div>
-          )}
-          <div>
-            <h3 className="font-semibold text-gray-900">{supplier.name}</h3>
-            <div className="flex items-center gap-1 text-sm text-gray-500">
-              <Star className="h-4 w-4 fill-warning-400 text-warning-400" />
-              <span>{supplier.rating}</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Badges */}
-        <div className="flex flex-col items-end gap-1">
-          {isCurrent && (
-            <Badge variant="info">
-              <Check className="mr-1 h-3 w-3" />
-              Current Supplier
-            </Badge>
-          )}
-          {supplier.greenEnergy && (
-            <Badge variant="success">
-              <Leaf className="mr-1 h-3 w-3" />
-              Green Energy
-            </Badge>
-          )}
-          <Badge variant="default">{supplier.tariffType}</Badge>
-        </div>
-      </div>
-
-      {/* Pricing */}
-      <div className="mt-4 grid grid-cols-2 gap-4">
-        <div>
-          <p className="text-sm text-gray-500">Price per kWh</p>
-          <p className="text-lg font-semibold text-gray-900">
-            {formatCurrency(supplier.avgPricePerKwh)}
-          </p>
-        </div>
-        <div>
-          <p className="text-sm text-gray-500">Est. Annual Cost</p>
-          <p className="text-lg font-semibold text-gray-900">
-            {formatCurrency(supplier.estimatedAnnualCost)}
-          </p>
-        </div>
-      </div>
-
-      {/* Savings indicator */}
-      {savings > 0 && (
-        <div className="mt-3 rounded-lg bg-success-50 p-3">
-          <p className="text-center text-success-700">
-            <span className="font-semibold">Save {formatCurrency(savings)}</span>
-            <span className="text-sm"> per year</span>
-          </p>
-        </div>
-      )}
-
-      {/* Detailed info */}
-      {showDetails && (
-        <div className="mt-4 space-y-2 border-t border-gray-100 pt-4">
-          <div className="flex justify-between text-sm">
-            <span className="text-gray-500">Standing Charge</span>
-            <span className="font-medium text-gray-900">
-              {formatCurrency(supplier.standingCharge)}/day
-            </span>
-          </div>
-
-          {supplier.exitFee && (
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-500">Exit Fee</span>
-              <span className="font-medium text-danger-600">
-                {formatCurrency(supplier.exitFee)}
-              </span>
-            </div>
-          )}
-
-          {supplier.contractLength && (
-            <div className="flex justify-between text-sm">
-              <span className="text-gray-500">Contract Length</span>
-              <span className="font-medium text-gray-900">
-                {supplier.contractLength} months
-              </span>
-            </div>
-          )}
-
-          {supplier.features && supplier.features.length > 0 && (
-            <div className="pt-2">
-              <p className="text-sm text-gray-500 mb-1">Features</p>
-              <div className="flex flex-wrap gap-1">
-                {supplier.features.map((feature) => (
-                  <Badge key={feature} variant="default" size="sm">
-                    {feature}
-                  </Badge>
-                ))}
+    return (
+      <Card
+        className={cn(
+          "transition-shadow hover:shadow-md",
+          isCurrent && "ring-2 ring-primary-500",
+          className,
+        )}
+        data-testid={`supplier-card-${supplier.id}`}
+      >
+        {/* Header with logo and name */}
+        <div className="flex items-start justify-between">
+          <div className="flex items-center gap-3">
+            {supplier.logo ? (
+              <Image
+                src={supplier.logo}
+                alt={`${supplier.name} logo`}
+                width={48}
+                height={48}
+                className="rounded-lg object-contain"
+              />
+            ) : (
+              <div
+                data-testid="supplier-logo-placeholder"
+                className="flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100"
+              >
+                <Zap className="h-6 w-6 text-gray-400" />
+              </div>
+            )}
+            <div>
+              <h3 className="font-semibold text-gray-900">{supplier.name}</h3>
+              <div className="flex items-center gap-1 text-sm text-gray-500">
+                <Star className="h-4 w-4 fill-warning-400 text-warning-400" />
+                <span>{supplier.rating}</span>
               </div>
             </div>
-          )}
-        </div>
-      )}
+          </div>
 
-      {/* Action button */}
-      {!isCurrent && onSelect && (
-        <div className="mt-4">
-          <Button
-            variant="primary"
-            className="w-full"
-            onClick={() => onSelect(supplier)}
-            onKeyDown={handleKeyDown}
-          >
-            Switch to {supplier.name}
-          </Button>
+          {/* Badges */}
+          <div className="flex flex-col items-end gap-1">
+            {isCurrent && (
+              <Badge variant="info">
+                <Check className="mr-1 h-3 w-3" />
+                Current Supplier
+              </Badge>
+            )}
+            {supplier.greenEnergy && (
+              <Badge variant="success">
+                <Leaf className="mr-1 h-3 w-3" />
+                Green Energy
+              </Badge>
+            )}
+            <Badge variant="default">{supplier.tariffType}</Badge>
+          </div>
         </div>
-      )}
-    </Card>
-  )
-})
 
-SupplierCard.displayName = 'SupplierCard'
+        {/* Pricing */}
+        <div className="mt-4 grid grid-cols-2 gap-4">
+          <div>
+            <p className="flex items-center gap-1.5 text-sm text-gray-500">
+              Price per kWh
+              {supplier.isEstimate && (
+                <span
+                  className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-gray-500"
+                  title="Estimated from the regional market rate — not a supplier-specific offer"
+                  data-testid="estimate-badge"
+                >
+                  Estimated
+                </span>
+              )}
+            </p>
+            <p className="text-lg font-semibold text-gray-900">
+              {formatCurrency(supplier.avgPricePerKwh)}
+            </p>
+          </div>
+          <div>
+            <p className="text-sm text-gray-500">Est. Annual Cost</p>
+            <p className="text-lg font-semibold text-gray-900">
+              {formatCurrency(supplier.estimatedAnnualCost)}
+            </p>
+          </div>
+        </div>
+
+        {/* Savings indicator */}
+        {savings > 0 && (
+          <div className="mt-3 rounded-lg bg-success-50 p-3">
+            <p className="text-center text-success-700">
+              <span className="font-semibold">
+                Save {formatCurrency(savings)}
+              </span>
+              <span className="text-sm"> per year</span>
+            </p>
+          </div>
+        )}
+
+        {/* Detailed info */}
+        {showDetails && (
+          <div className="mt-4 space-y-2 border-t border-gray-100 pt-4">
+            <div className="flex justify-between text-sm">
+              <span className="text-gray-500">Standing Charge</span>
+              <span className="font-medium text-gray-900">
+                {formatCurrency(supplier.standingCharge)}/day
+              </span>
+            </div>
+
+            {supplier.exitFee && (
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-500">Exit Fee</span>
+                <span className="font-medium text-danger-600">
+                  {formatCurrency(supplier.exitFee)}
+                </span>
+              </div>
+            )}
+
+            {supplier.contractLength && (
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-500">Contract Length</span>
+                <span className="font-medium text-gray-900">
+                  {supplier.contractLength} months
+                </span>
+              </div>
+            )}
+
+            {supplier.features && supplier.features.length > 0 && (
+              <div className="pt-2">
+                <p className="text-sm text-gray-500 mb-1">Features</p>
+                <div className="flex flex-wrap gap-1">
+                  {supplier.features.map((feature) => (
+                    <Badge key={feature} variant="default" size="sm">
+                      {feature}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Action button */}
+        {!isCurrent && onSelect && (
+          <div className="mt-4">
+            <Button
+              variant="primary"
+              className="w-full"
+              onClick={() => onSelect(supplier)}
+              onKeyDown={handleKeyDown}
+            >
+              Switch to {supplier.name}
+            </Button>
+          </div>
+        )}
+      </Card>
+    );
+  },
+);
+
+SupplierCard.displayName = "SupplierCard";

--- a/frontend/components/suppliers/SuppliersContent.tsx
+++ b/frontend/components/suppliers/SuppliersContent.tsx
@@ -174,6 +174,8 @@ export default function SuppliersContent() {
       exitFee: s.exitFee ?? s.exit_fee,
       contractLength: s.contractLength ?? s.contract_length,
       features: s.features ?? s.tariff_types,
+      pricingSource: s.pricing_source,
+      isEstimate: s.is_estimate ?? false,
     }),
   );
   const recommendation = recommendationData?.recommendation;

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -13,24 +13,24 @@
  */
 export interface RawPricePoint {
   /** Frontend-friendly field (normalized by price service) */
-  price?: number | null
+  price?: number | null;
   /** Database column name from electricity_prices table */
-  price_per_kwh?: number | null
+  price_per_kwh?: number | null;
   /** Backend alternative field name for current price */
-  current_price?: number | null
+  current_price?: number | null;
   /** Frontend-friendly timestamp field */
-  time?: string | number
+  time?: string | number;
   /** Database column name */
-  timestamp?: string | number
+  timestamp?: string | number;
   /** Forecast flag on history records */
-  forecast?: number | null
+  forecast?: number | null;
   /** Percentage change over 24 h (frontend-friendly) */
-  changePercent?: number | null
+  changePercent?: number | null;
   /** Percentage change over 24 h (backend field name) */
-  price_change_24h?: number | null
-  trend?: 'increasing' | 'decreasing' | 'stable'
-  region?: string
-  supplier?: string
+  price_change_24h?: number | null;
+  trend?: "increasing" | "decreasing" | "stable";
+  region?: string;
+  supplier?: string;
 }
 
 /**
@@ -39,9 +39,9 @@ export interface RawPricePoint {
  * a flat array of ForecastPoint objects (frontend shape).
  */
 export interface RawForecastPriceEntry {
-  price?: number | null
-  price_per_kwh?: number | null
-  timestamp?: string
+  price?: number | null;
+  price_per_kwh?: number | null;
+  timestamp?: string;
 }
 
 /**
@@ -52,49 +52,53 @@ export interface RawForecastPriceEntry {
  * the backend schema (backend returns null, not undefined).
  */
 export interface RawSupplierRecord {
-  id: string
-  name: string
+  id: string;
+  name: string;
   /** Backend snake_case list of region codes (e.g. ["us_ct"]) */
-  regions?: string[]
+  regions?: string[];
   /** Backend snake_case list of tariff type strings */
-  tariff_types?: string[]
+  tariff_types?: string[];
   /** Backend: whether a supplier API integration is available */
-  api_available?: boolean
+  api_available?: boolean;
   /** Backend snake_case */
-  green_energy_provider?: boolean
+  green_energy_provider?: boolean;
   /** Backend active status */
-  is_active?: boolean
+  is_active?: boolean;
   /** Backend field */
-  logo_url?: string
+  logo_url?: string;
   /** Frontend-normalized field */
-  logo?: string
+  logo?: string;
   /** Frontend camelCase */
-  avgPricePerKwh?: number
+  avgPricePerKwh?: number;
   /** Backend snake_case */
-  avg_price_per_kwh?: number
+  avg_price_per_kwh?: number;
   /** Frontend camelCase */
-  standingCharge?: number
+  standingCharge?: number;
   /** Backend snake_case */
-  standing_charge?: number
+  standing_charge?: number;
   /** Frontend camelCase */
-  greenEnergy?: boolean
+  greenEnergy?: boolean;
   /** Rating returned as number | null from the backend */
-  rating?: number | null
+  rating?: number | null;
   /** Frontend camelCase */
-  estimatedAnnualCost?: number
+  estimatedAnnualCost?: number;
   /** Backend snake_case */
-  estimated_annual_cost?: number
+  estimated_annual_cost?: number;
   /** Frontend camelCase */
-  tariffType?: 'fixed' | 'variable' | 'time-of-use'
+  tariffType?: "fixed" | "variable" | "time-of-use";
   /** Frontend camelCase */
-  exitFee?: number
+  exitFee?: number;
   /** Backend snake_case */
-  exit_fee?: number
+  exit_fee?: number;
   /** Frontend camelCase */
-  contractLength?: number
+  contractLength?: number;
   /** Backend snake_case */
-  contract_length?: number
-  features?: string[]
+  contract_length?: number;
+  features?: string[];
+  /** Backend: which source the pricing came from (e.g. 'regional_estimate', 'ct_rate_board') */
+  pricing_source?: string;
+  /** Backend: true when the price is a derived estimate, not an obtainable offer */
+  is_estimate?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,155 +106,159 @@ export interface RawSupplierRecord {
 // ---------------------------------------------------------------------------
 
 export interface PriceDataPoint {
-  time: string
-  price: number | null
-  forecast: number | null
-  isOptimal?: boolean
-  confidenceLow?: number
-  confidenceHigh?: number
+  time: string;
+  price: number | null;
+  forecast: number | null;
+  isOptimal?: boolean;
+  confidenceLow?: number;
+  confidenceHigh?: number;
 }
 
 export interface CurrentPrice {
-  region: string
-  price: number
-  timestamp: string
-  trend: 'increasing' | 'decreasing' | 'stable'
-  changePercent: number
+  region: string;
+  price: number;
+  timestamp: string;
+  trend: "increasing" | "decreasing" | "stable";
+  changePercent: number;
 }
 
 export interface PriceForecast {
-  hour: number
-  price: number
-  confidence: [number, number]
-  timestamp: string
+  hour: number;
+  price: number;
+  confidence: [number, number];
+  timestamp: string;
 }
 
 // Supplier types
 export interface Supplier {
-  id: string
-  name: string
-  logo?: string
-  avgPricePerKwh: number
-  standingCharge: number
-  greenEnergy: boolean
-  rating: number
-  estimatedAnnualCost: number
-  exitFee?: number
-  tariffType: 'fixed' | 'variable' | 'time-of-use'
-  contractLength?: number
-  features?: string[]
+  id: string;
+  name: string;
+  logo?: string;
+  avgPricePerKwh: number;
+  standingCharge: number;
+  greenEnergy: boolean;
+  rating: number;
+  estimatedAnnualCost: number;
+  exitFee?: number;
+  tariffType: "fixed" | "variable" | "time-of-use";
+  contractLength?: number;
+  features?: string[];
+  /** Pricing provenance: which source produced the rate. */
+  pricingSource?: string;
+  /** True when the rate is a derived estimate rather than an obtainable offer. */
+  isEstimate?: boolean;
 }
 
 export interface SupplierRecommendation {
-  supplier: Supplier
-  currentSupplier: Supplier
-  estimatedSavings: number
-  paybackMonths: number
-  confidence: number
+  supplier: Supplier;
+  currentSupplier: Supplier;
+  estimatedSavings: number;
+  paybackMonths: number;
+  confidence: number;
 }
 
 // Optimization types
 export interface Appliance {
-  id: string
-  name: string
-  powerKw: number
-  typicalDurationHours: number
-  isFlexible: boolean
+  id: string;
+  name: string;
+  powerKw: number;
+  typicalDurationHours: number;
+  isFlexible: boolean;
   preferredTimeRange?: {
-    start: number
-    end: number
-  }
-  priority: 'high' | 'medium' | 'low'
+    start: number;
+    end: number;
+  };
+  priority: "high" | "medium" | "low";
 }
 
 export interface OptimizationSchedule {
-  applianceId: string
-  applianceName: string
-  scheduledStart: string
-  scheduledEnd: string
-  estimatedCost: number
-  savings: number
-  reason: string
+  applianceId: string;
+  applianceName: string;
+  scheduledStart: string;
+  scheduledEnd: string;
+  estimatedCost: number;
+  savings: number;
+  reason: string;
 }
 
 export interface OptimizationResult {
-  schedules: OptimizationSchedule[]
-  totalSavings: number
-  totalCost: number
+  schedules: OptimizationSchedule[];
+  totalSavings: number;
+  totalCost: number;
   optimalPeriods: {
-    start: string
-    end: string
-    avgPrice: number
-  }[]
+    start: string;
+    end: string;
+    avgPrice: number;
+  }[];
 }
 
 // User settings types
 export interface UserSettings {
-  region: string
-  currentSupplier: Supplier | null
-  annualUsageKwh: number
-  peakDemandKw: number
-  appliances: Appliance[]
+  region: string;
+  currentSupplier: Supplier | null;
+  annualUsageKwh: number;
+  peakDemandKw: number;
+  appliances: Appliance[];
   notificationPreferences: {
-    priceAlerts: boolean
-    optimalTimes: boolean
-    supplierUpdates: boolean
-  }
+    priceAlerts: boolean;
+    optimalTimes: boolean;
+    supplierUpdates: boolean;
+  };
   displayPreferences: {
-    currency: 'USD' | 'GBP' | 'EUR'
-    theme: 'light' | 'dark' | 'system'
-    timeFormat: '12h' | '24h'
-  }
+    currency: "USD" | "GBP" | "EUR";
+    theme: "light" | "dark" | "system";
+    timeFormat: "12h" | "24h";
+  };
 }
 
 // Dashboard widget types
 export interface DashboardSummary {
-  currentPrice: CurrentPrice
-  todaySavings: number
-  monthSavings: number
-  totalSavings: number
+  currentPrice: CurrentPrice;
+  todaySavings: number;
+  monthSavings: number;
+  totalSavings: number;
   nextOptimalPeriod: {
-    start: string
-    end: string
-    price: number
-  } | null
-  supplierRecommendation: SupplierRecommendation | null
+    start: string;
+    end: string;
+    price: number;
+  } | null;
+  supplierRecommendation: SupplierRecommendation | null;
 }
 
 // API response types
 export interface ApiResponse<T> {
-  data: T
-  success: boolean
-  error?: string
-  timestamp: string
+  data: T;
+  success: boolean;
+  error?: string;
+  timestamp: string;
 }
 
 export interface PaginatedResponse<T> {
-  items: T[]
-  total: number
-  page: number
-  pageSize: number
-  hasMore: boolean
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
 }
 
 // Chart configuration types
 export interface ChartConfig {
-  showForecast?: boolean
-  highlightOptimal?: boolean
-  timeRange?: '6h' | '12h' | '24h' | '48h' | '7d'
-  showVolume?: boolean
-  showConfidence?: boolean
+  showForecast?: boolean;
+  highlightOptimal?: boolean;
+  timeRange?: "6h" | "12h" | "24h" | "48h" | "7d";
+  showVolume?: boolean;
+  showConfidence?: boolean;
 }
 
 // Form types
 export interface SwitchWizardState {
-  step: 1 | 2 | 3 | 4
-  recommendation: SupplierRecommendation
-  gdprConsent: boolean
-  contractAccepted: boolean
-  isSubmitting: boolean
-  error?: string
+  step: 1 | 2 | 3 | 4;
+  recommendation: SupplierRecommendation;
+  gdprConsent: boolean;
+  contractAccepted: boolean;
+  isSubmitting: boolean;
+  error?: string;
 }
 
 // Event types
-export type TimeRange = '6h' | '12h' | '24h' | '48h' | '7d'
+export type TimeRange = "6h" | "12h" | "24h" | "48h" | "7d";


### PR DESCRIPTION
Decouples supplier pricing from any single provider, so `/suppliers` and `/suppliers/recommend` read from a source-agnostic store and new data sources drop in as adapters with **no API or frontend change**.

> Stacked on #102 (audit fixes) — review/merge that first. Base will retarget to `main` once #102 merges.

## Why
The audit found all suppliers showing $0.00. Root cause was a data gap (empty `tariffs`, unlinked from `supplier_registry`). Rather than couple to one vendor (and after deciding **not** to depend on EnergyBot, a competitor), this lands a neutral read model: today it serves an honest labeled estimate; tomorrow CT-board / Arcadia / an in-house ingester plug in behind the same contract.

## What
**Backend**
- **Migration 069** — `supplier_offers` (region/zip-keyed, provenance + lifecycle, rate structure: intro/variable/fees/renewable/enroll_url). `tariffs` left in place but **deprecated**. *(Applied to Neon `cold-rice-23455092`.)*
- `SupplierOffer` model + `annual_cost()`.
- `services/pricing/`: `SupplierOfferSource` protocol + `RegionalEstimateSource` (only wired source; computed live, `is_estimate=true`).
- `SupplierOfferRepository`: `cheapest_available_by_supplier` (real-over-estimate, expiry/staleness-gated, estimate fallback) + idempotent `upsert_offers` for future sync jobs.
- `/suppliers` + `/suppliers/recommend` now offer-driven. Recommend returns `null` unless a **real** cheaper offer beats the current supplier.
- `SupplierResponse` gains `pricing_source` + `is_estimate`.

**Frontend**
- `Supplier`/`RawSupplierRecord` gain `pricingSource`/`isEstimate`; `SupplierCard` shows an **"Estimated"** badge (honest labeling — closes the design-review objection that uniform regional prices look misleading).

## Adding a real source later (no read-path change)
Implement a `SupplierOfferSource`, schedule a sync job calling `upsert_offers(...)`. That's it.

## Tests
Backend **4045 pass** (10 integration skipped), frontend **3441 pass**. New: offer-repo selection (real-over-estimate, staleness fallback), adapter normalization, recommend cases (estimates→null, real→savings, already-cheapest→null), pricing-label + badge cases.

## Deploy note
Migration 069 is **applied to Neon already** (additive, `CREATE TABLE IF NOT EXISTS`). The read query runs cleanly against the empty table (falls back to the live estimate), so no ordering hazard.

## Follow-ups
- DSP graph update for the new modules (deferred to post-merge to avoid colliding with `main` automation).
- Decide the first **real** source (CT rate board with ToS clearance, or Arcadia) and implement its adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)