### PR TITLE
test(e2e): reconcile smoke suite to green + reduce full-suite regressions (#109)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -159,6 +159,11 @@ jobs:
           # mounts all routes under /api/v1.
           NEXT_PUBLIC_API_URL: /api/v1
           BACKEND_URL: http://localhost:8000
+          # Enable OAuth buttons (Google/GitHub) at build time so the
+          # authentication "shows OAuth login options" E2E test can see them.
+          # These NEXT_PUBLIC_* flags are inlined at build, matching production.
+          NEXT_PUBLIC_OAUTH_GOOGLE_ENABLED: 'true'
+          NEXT_PUBLIC_OAUTH_GITHUB_ENABLED: 'true'
 
       - name: Wait for frontend
         uses: ./.github/actions/wait-for-service

--- a/frontend/app/(app)/optimize/page.tsx
+++ b/frontend/app/(app)/optimize/page.tsx
@@ -252,6 +252,9 @@ export default function OptimizePage() {
                     variant="ghost"
                     size="sm"
                     onClick={() => setIsEditing(!isEditing)}
+                    aria-label={
+                      isEditing ? "Done editing appliances" : "Edit appliances"
+                    }
                   >
                     <Settings className="h-4 w-4" />
                   </Button>

--- a/frontend/app/(app)/settings/page.tsx
+++ b/frontend/app/(app)/settings/page.tsx
@@ -319,6 +319,7 @@ export default function SettingsPage() {
                     </p>
                   </div>
                   <select
+                    aria-label="Region"
                     value={region || ""}
                     onChange={(e) => setRegion(e.target.value)}
                     className="rounded-lg border border-gray-300 bg-white text-gray-900 px-3 py-2 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 transition-colors duration-200"
@@ -629,6 +630,7 @@ export default function SettingsPage() {
                   </p>
                 </div>
                 <select
+                  aria-label="Currency"
                   value={displayPreferences.currency}
                   onChange={(e) =>
                     setDisplayPreferences({
@@ -651,6 +653,7 @@ export default function SettingsPage() {
                   </p>
                 </div>
                 <select
+                  aria-label="Theme"
                   value={displayPreferences.theme}
                   onChange={(e) =>
                     setDisplayPreferences({
@@ -673,6 +676,7 @@ export default function SettingsPage() {
                   </p>
                 </div>
                 <select
+                  aria-label="Time format"
                   value={displayPreferences.timeFormat}
                   onChange={(e) =>
                     setDisplayPreferences({

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -84,7 +84,7 @@ export default function PrivacyPage() {
             terms; see{" "}
             <a
               href="https://utilityapi.com/privacy"
-              className="text-blue-600 hover:underline"
+              className="text-blue-600 underline"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/frontend/components/dashboard/DashboardStatsRow.tsx
+++ b/frontend/components/dashboard/DashboardStatsRow.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import Link from 'next/link'
-import { Card, CardContent } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
-import { formatCurrency } from '@/lib/utils/format'
-import { cn } from '@/lib/utils/cn'
-import { Zap, Clock, ArrowRight } from 'lucide-react'
-import type { DashboardStatsRowProps } from './DashboardTypes'
+import React from "react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { formatCurrency } from "@/lib/utils/format";
+import { cn } from "@/lib/utils/cn";
+import { Zap, Clock, ArrowRight } from "lucide-react";
+import type { DashboardStatsRowProps } from "./DashboardTypes";
 
 /**
  * Renders the top row of four dashboard stat cards:
@@ -28,9 +28,7 @@ export const DashboardStatsRow = React.memo(function DashboardStatsRow({
       <Card>
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-gray-500">
-              Current Price
-            </p>
+            <p className="text-sm font-medium text-gray-500">Current Price</p>
             <Zap className="h-5 w-5 text-primary-500" />
           </div>
           <div className="mt-2 flex items-baseline gap-2">
@@ -38,28 +36,26 @@ export const DashboardStatsRow = React.memo(function DashboardStatsRow({
               data-testid="current-price"
               className="text-2xl font-bold text-gray-900"
             >
-              {currentPrice
-                ? formatCurrency(currentPrice.price)
-                : '--'}
+              {currentPrice ? formatCurrency(currentPrice.price) : "--"}
             </p>
             <span className="text-sm text-gray-500">/kWh</span>
           </div>
           <div
             data-testid="price-trend"
             className={cn(
-              'mt-2 flex items-center gap-1 text-sm',
-              trend === 'increasing'
-                ? 'text-danger-600'
-                : trend === 'decreasing'
-                  ? 'text-success-600'
-                  : 'text-gray-500'
+              "mt-2 flex items-center gap-1 text-sm",
+              trend === "increasing"
+                ? "text-danger-600"
+                : trend === "decreasing"
+                  ? "text-success-600"
+                  : "text-gray-500",
             )}
           >
             <TrendIcon className="h-4 w-4" />
             <span>
               {currentPrice?.changePercent
-                ? `${currentPrice.changePercent > 0 ? '+' : ''}${currentPrice.changePercent.toFixed(1)}%`
-                : 'Stable'}
+                ? `${currentPrice.changePercent > 0 ? "+" : ""}${currentPrice.changePercent.toFixed(1)}%`
+                : "Stable"}
             </span>
           </div>
         </CardContent>
@@ -69,20 +65,20 @@ export const DashboardStatsRow = React.memo(function DashboardStatsRow({
       <Card>
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-gray-500">
-              Total Saved
-            </p>
+            <p className="text-sm font-medium text-gray-500">Total Saved</p>
             {savingsData && savingsData.streak_days > 0 && (
-              <Badge variant="success">{savingsData.streak_days}-day streak</Badge>
+              <Badge variant="success">
+                {savingsData.streak_days}-day streak
+              </Badge>
             )}
           </div>
           <p className="mt-2 text-2xl font-bold text-success-600">
-            {savingsData ? formatCurrency(savingsData.monthly) : '--'}
+            {savingsData ? formatCurrency(savingsData.monthly) : "--"}
           </p>
           <p className="mt-1 text-sm text-gray-500">
             {savingsData
               ? `${formatCurrency(savingsData.weekly / 7)} today`
-              : 'Start saving to track'}
+              : "Start saving to track"}
           </p>
         </CardContent>
       </Card>
@@ -91,9 +87,7 @@ export const DashboardStatsRow = React.memo(function DashboardStatsRow({
       <Card>
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-gray-500">
-              Optimal Times
-            </p>
+            <p className="text-sm font-medium text-gray-500">Optimal Times</p>
             <Clock className="h-5 w-5 text-warning-500" />
           </div>
           {optimalWindow ? (
@@ -106,9 +100,9 @@ export const DashboardStatsRow = React.memo(function DashboardStatsRow({
               </p>
             </>
           ) : forecastLoading ? (
-            <p className="mt-2 text-lg text-gray-400">Loading forecast...</p>
+            <p className="mt-2 text-lg text-gray-500">Loading forecast...</p>
           ) : (
-            <p className="mt-2 text-lg text-gray-400">No forecast data</p>
+            <p className="mt-2 text-lg text-gray-500">No forecast data</p>
           )}
         </CardContent>
       </Card>
@@ -117,10 +111,12 @@ export const DashboardStatsRow = React.memo(function DashboardStatsRow({
       <Card>
         <CardContent className="p-4">
           <div className="flex items-center justify-between">
-            <p className="text-sm font-medium text-gray-500">
-              Suppliers
-            </p>
-            {currentSupplier && topSuppliers.some(s => s.estimatedAnnualCost < currentSupplier.estimatedAnnualCost) ? (
+            <p className="text-sm font-medium text-gray-500">Suppliers</p>
+            {currentSupplier &&
+            topSuppliers.some(
+              (s) =>
+                s.estimatedAnnualCost < currentSupplier.estimatedAnnualCost,
+            ) ? (
               <Badge variant="success">Cheaper available</Badge>
             ) : null}
           </div>
@@ -137,5 +133,5 @@ export const DashboardStatsRow = React.memo(function DashboardStatsRow({
         </CardContent>
       </Card>
     </div>
-  )
-})
+  );
+});

--- a/frontend/components/dashboard/DashboardTabs.tsx
+++ b/frontend/components/dashboard/DashboardTabs.tsx
@@ -66,6 +66,7 @@ export default function DashboardTabs() {
           className="flex gap-0 overflow-x-auto scrollbar-hide px-4 sm:px-6"
           aria-label="Dashboard tabs"
           data-testid="tab-bar"
+          role="tablist"
         >
           {visibleTabs.map((tab) => (
             <button

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -165,11 +165,12 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
               </a>
               <div className="flex items-center gap-3 px-3 py-1">
                 <FileText className="h-4 w-4 text-gray-400" />
-                <div className="flex gap-2 text-xs text-gray-400">
+                {/* gray-600 (not gray-400) so the link text meets WCAG AA contrast */}
+                <div className="flex gap-2 text-xs text-gray-600">
                   <Link
                     href="/terms"
                     onClick={onNavigate}
-                    className="hover:text-gray-600"
+                    className="hover:text-gray-900"
                   >
                     Terms
                   </Link>
@@ -177,13 +178,14 @@ function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
                   <Link
                     href="/privacy"
                     onClick={onNavigate}
-                    className="hover:text-gray-600"
+                    className="hover:text-gray-900"
                   >
                     Privacy
                   </Link>
                 </div>
               </div>
-              <p className="px-3 py-1 text-[10px] text-gray-300">v1.0.0</p>
+              {/* gray-500 (not gray-300) for WCAG AA contrast on the version text */}
+              <p className="px-3 py-1 text-[10px] text-gray-500">v1.0.0</p>
             </div>
           </div>
         ) : (

--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -517,7 +517,12 @@ test.describe("Accessibility — Heading Hierarchy", () => {
       waitUntil: "domcontentloaded",
       timeout: 15000,
     });
-    await authenticatedPage.waitForSelector("body");
+    // Wait for the dashboard to render past its loading skeleton — the h1 lives
+    // in the Header, which only mounts once the price data resolves.
+    await authenticatedPage
+      .locator("h1")
+      .first()
+      .waitFor({ state: "visible", timeout: 10000 });
 
     const headingData = await authenticatedPage.evaluate(() => {
       const headings = Array.from(

--- a/frontend/e2e/api-contracts.spec.ts
+++ b/frontend/e2e/api-contracts.spec.ts
@@ -250,16 +250,15 @@ test.describe("API Contracts — Error States", () => {
     authenticatedPage,
   }) => {
     // Override the default mock with a 500 response (LIFO — registered after fixture)
-    await authenticatedPage.route(
-      "**/api/v1/prices/current**",
-      async (route) => {
+    await authenticatedPage
+      .context()
+      .route("**/api/v1/prices/current**", async (route) => {
         await route.fulfill({
           status: 500,
           contentType: "application/json",
           body: JSON.stringify({ detail: "Internal server error" }),
         });
-      },
-    );
+      });
 
     await authenticatedPage.goto("/prices", {
       waitUntil: "domcontentloaded",
@@ -280,16 +279,15 @@ test.describe("API Contracts — Error States", () => {
   test("dashboard shows error UI when prices/current returns 500 @regression", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.route(
-      "**/api/v1/prices/current**",
-      async (route) => {
+    await authenticatedPage
+      .context()
+      .route("**/api/v1/prices/current**", async (route) => {
         await route.fulfill({
           status: 500,
           contentType: "application/json",
           body: JSON.stringify({ detail: "Internal server error" }),
         });
-      },
-    );
+      });
 
     await authenticatedPage.goto("/dashboard", {
       waitUntil: "domcontentloaded",
@@ -307,13 +305,15 @@ test.describe("API Contracts — Error States", () => {
   test("suppliers page shows error UI when suppliers returns 404 @regression", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.route("**/api/v1/suppliers**", async (route) => {
-      await route.fulfill({
-        status: 404,
-        contentType: "application/json",
-        body: JSON.stringify({ detail: "Not found" }),
+    await authenticatedPage
+      .context()
+      .route("**/api/v1/suppliers**", async (route) => {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Not found" }),
+        });
       });
-    });
 
     await authenticatedPage.goto("/suppliers", {
       waitUntil: "domcontentloaded",
@@ -331,9 +331,9 @@ test.describe("API Contracts — Error States", () => {
   test("gated forecast endpoint returns 403 and shows upgrade prompt @regression", async ({
     authenticatedPage,
   }) => {
-    await authenticatedPage.route(
-      "**/api/v1/prices/forecast**",
-      async (route) => {
+    await authenticatedPage
+      .context()
+      .route("**/api/v1/prices/forecast**", async (route) => {
         await route.fulfill({
           status: 403,
           contentType: "application/json",
@@ -343,8 +343,7 @@ test.describe("API Contracts — Error States", () => {
             required_tier: "pro",
           }),
         });
-      },
-    );
+      });
 
     await authenticatedPage.goto("/dashboard", {
       waitUntil: "domcontentloaded",
@@ -384,9 +383,9 @@ test.describe("API Contracts — Retry Behavior", () => {
     let callCount = 0;
 
     // Register override AFTER fixture mocks (LIFO — takes priority)
-    await authenticatedPage.route(
-      "**/api/v1/prices/current**",
-      async (route) => {
+    await authenticatedPage
+      .context()
+      .route("**/api/v1/prices/current**", async (route) => {
         callCount++;
         if (callCount === 1) {
           await route.fulfill({
@@ -423,8 +422,7 @@ test.describe("API Contracts — Retry Behavior", () => {
             }),
           });
         }
-      },
-    );
+      });
 
     await authenticatedPage.goto("/dashboard", {
       waitUntil: "domcontentloaded",
@@ -451,35 +449,37 @@ test.describe("API Contracts — Retry Behavior", () => {
   }) => {
     let callCount = 0;
 
-    await authenticatedPage.route("**/api/v1/suppliers**", async (route) => {
-      callCount++;
-      if (callCount === 1) {
-        await route.fulfill({
-          status: 500,
-          contentType: "application/json",
-          body: JSON.stringify({ detail: "Transient failure" }),
-        });
-      } else {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({
-            suppliers: [
-              {
-                id: "1",
-                name: "Eversource Energy",
-                avgPricePerKwh: 0.25,
-                standingCharge: 0.5,
-                greenEnergy: true,
-                rating: 4.5,
-                estimatedAnnualCost: 1200,
-                tariffType: "variable",
-              },
-            ],
-          }),
-        });
-      }
-    });
+    await authenticatedPage
+      .context()
+      .route("**/api/v1/suppliers**", async (route) => {
+        callCount++;
+        if (callCount === 1) {
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "Transient failure" }),
+          });
+        } else {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({
+              suppliers: [
+                {
+                  id: "1",
+                  name: "Eversource Energy",
+                  avgPricePerKwh: 0.25,
+                  standingCharge: 0.5,
+                  greenEnergy: true,
+                  rating: 4.5,
+                  estimatedAnnualCost: 1200,
+                  tariffType: "variable",
+                },
+              ],
+            }),
+          });
+        }
+      });
 
     await authenticatedPage.goto("/suppliers", {
       waitUntil: "domcontentloaded",
@@ -511,9 +511,9 @@ test.describe("API Contracts — Community Page", () => {
     });
 
     // Override communityPosts mock so it returns data (default is undefined)
-    await authenticatedPage.route(
-      "**/api/v1/community/posts**",
-      async (route) => {
+    await authenticatedPage
+      .context()
+      .route("**/api/v1/community/posts**", async (route) => {
         if (route.request().method() === "GET") {
           await route.fulfill({
             status: 200,
@@ -528,8 +528,7 @@ test.describe("API Contracts — Community Page", () => {
         } else {
           await route.continue();
         }
-      },
-    );
+      });
 
     const postsPromise = authenticatedPage.waitForRequest(
       (req) => req.url().includes("/community/posts"),

--- a/frontend/e2e/api-contracts.spec.ts
+++ b/frontend/e2e/api-contracts.spec.ts
@@ -184,8 +184,11 @@ test.describe("API Contracts — Suppliers Page", () => {
       if (req.url().includes("/api/v1/")) calledUrls.push(req.url());
     });
 
+    // Match the API call, not the page navigation: goto("/suppliers") issues a
+    // document request whose URL also contains "/suppliers", which would
+    // resolve this wait before the client-side API call ever fires.
     const suppliersPromise = authenticatedPage.waitForRequest(
-      (req) => req.url().includes("/suppliers"),
+      (req) => req.url().includes("/api/v1/suppliers"),
       { timeout: 10000 },
     );
 
@@ -557,8 +560,11 @@ test.describe("API Contracts — Alerts Page", () => {
       if (req.url().includes("/api/v1/")) calledUrls.push(req.url());
     });
 
+    // Match the API call, not the page navigation: goto("/alerts") issues a
+    // document request whose URL also contains "/alerts", which would resolve
+    // this wait before the client-side API call ever fires.
     const alertsPromise = authenticatedPage.waitForRequest(
-      (req) => req.url().includes("/alerts"),
+      (req) => req.url().includes("/api/v1/alerts"),
       { timeout: 10000 },
     );
 

--- a/frontend/e2e/authentication.spec.ts
+++ b/frontend/e2e/authentication.spec.ts
@@ -4,6 +4,7 @@ import {
   setAuthenticatedState,
   clearAuthState,
 } from "./helpers/auth";
+import { createMockApi } from "./helpers/api-mocks";
 
 test.describe("Authentication Flows", () => {
   // Tests in this block exercise the login page (unauthenticated), OAuth initiation,
@@ -15,7 +16,7 @@ test.describe("Authentication Flows", () => {
     await page.goto("/auth/login");
 
     await expect(
-      page.getByRole("heading", { name: /electricity optimizer/i }),
+      page.getByRole("heading", { name: /rateshift/i }),
     ).toBeVisible();
     await expect(page.locator("#email")).toBeVisible();
     await expect(page.locator("#password")).toBeVisible();
@@ -29,6 +30,11 @@ test.describe("Authentication Flows", () => {
     { tag: ["@smoke"] },
     async ({ page }) => {
       await mockBetterAuth(page);
+      // Full dashboard mock coverage (incl. the SSE prices/stream mock) so the
+      // post-login dashboard renders instead of erroring. authSession:false
+      // leaves session handling to mockBetterAuth above. The test's own
+      // prices/current mock below is registered later and takes precedence.
+      await createMockApi(page, { authSession: false });
 
       await page.route("**/api/v1/prices/current**", async (route) => {
         await route.fulfill({
@@ -301,9 +307,16 @@ test.describe("Authentication Flows", () => {
       );
       await mockBetterAuth(page);
       await setAuthenticatedState(page);
+      // Mock dashboard APIs so an unmocked 401 doesn't auto-redirect to login
+      // (which would strip the sidebar sign-out button before we can click it).
+      await createMockApi(page, { authSession: false });
+      // The sidebar nav isn't scrollable; at the default 720px height its footer
+      // (the sign-out button) is clipped below the viewport and unclickable.
+      // Use a taller viewport so the button is reachable.
+      await page.setViewportSize({ width: 1280, height: 1400 });
       await page.goto("/dashboard");
 
-      await page.click('[data-testid="sign-out-button"]');
+      await page.locator('[data-testid="sign-out-button"]').click();
 
       await page.waitForURL("/auth/login", { timeout: 15000 });
     },

--- a/frontend/e2e/authentication.spec.ts
+++ b/frontend/e2e/authentication.spec.ts
@@ -388,6 +388,8 @@ test.describe("Authentication Flows", () => {
       // Set up authenticated state via cookie
       await setAuthenticatedState(page);
       await mockBetterAuth(page); // re-mock after setting cookies
+      // Full dashboard API mocks so the page renders instead of erroring.
+      await createMockApi(page, { authSession: false });
 
       await page.addInitScript(() => {
         localStorage.setItem(
@@ -425,6 +427,8 @@ test.describe("Authentication Flows", () => {
       // Set cookie but mock get-session to return null (expired)
       await setAuthenticatedState(page);
       await mockBetterAuth(page, { sessionExpired: true });
+      // Full dashboard API mocks so the dashboard branch renders if not redirected.
+      await createMockApi(page, { authSession: false });
 
       await page.goto("/dashboard");
 
@@ -592,10 +596,14 @@ test.describe("Authentication Security", () => {
       );
       await setAuthenticatedState(page);
       await mockBetterAuth(page);
+      // Full dashboard API mocks so an unmocked 401 doesn't strip the sidebar.
+      await createMockApi(page, { authSession: false });
+      // Sidebar nav isn't scrollable; at 720px the sign-out footer is clipped.
+      await page.setViewportSize({ width: 1280, height: 1400 });
 
       await page.goto("/dashboard");
 
-      await page.click('[data-testid="sign-out-button"]');
+      await page.locator('[data-testid="sign-out-button"]').click();
 
       // Wait for the sign-out to complete and redirect to login page
       await page.waitForURL(/\/auth\/login/, { timeout: 15000 });

--- a/frontend/e2e/auto-switcher-history.spec.ts
+++ b/frontend/e2e/auto-switcher-history.spec.ts
@@ -111,46 +111,54 @@ async function setupHistoryRoutes(
   } = {},
 ) {
   // Settings (needed for sidebar badge)
-  await page.route("**/api/v1/agent-switcher/settings", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        enabled: true,
-        savings_threshold_pct: 10,
-        savings_threshold_min: 10,
-        cooldown_days: 5,
-        paused_until: null,
-        loa_signed: false,
-        loa_revoked: false,
-        created_at: "2026-03-01T00:00:00Z",
-        updated_at: "2026-03-01T00:00:00Z",
-      }),
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/settings", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          enabled: true,
+          savings_threshold_pct: 10,
+          savings_threshold_min: 10,
+          cooldown_days: 5,
+          paused_until: null,
+          loa_signed: false,
+          loa_revoked: false,
+          created_at: "2026-03-01T00:00:00Z",
+          updated_at: "2026-03-01T00:00:00Z",
+        }),
+      });
     });
-  });
 
-  // History
-  await page.route("**/api/v1/agent-switcher/history**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(overrides.history ?? MOCK_HISTORY),
+  // History — getHistory() reads `res.history`, so the endpoint must return
+  // a { history, total } envelope, not a bare array.
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/history**", async (route) => {
+      const entries = overrides.history ?? MOCK_HISTORY;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ history: entries, total: entries.length }),
+      });
     });
-  });
 
   // Activity (for sidebar badge)
-  await page.route("**/api/v1/agent-switcher/activity**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify([]),
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/activity**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
     });
-  });
 
   // Rollback
-  await page.route(
-    "**/api/v1/agent-switcher/executions/*/rollback",
-    async (route) => {
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/executions/*/rollback", async (route) => {
       if (overrides.rollbackError) {
         await route.fulfill({
           status: 400,
@@ -166,8 +174,7 @@ async function setupHistoryRoutes(
           overrides.rollbackResponse ?? MOCK_ROLLBACK_RESPONSE,
         ),
       });
-    },
-  );
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -409,27 +416,33 @@ test.describe("Auto Switcher — History", () => {
     "history 500 shows error boundary",
     { tag: ["@regression"] },
     async ({ authenticatedPage: page }) => {
-      await page.route("**/api/v1/agent-switcher/settings", async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({}),
+      await page
+        .context()
+        .route("**/api/v1/agent-switcher/settings", async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify({}),
+          });
         });
-      });
-      await page.route("**/api/v1/agent-switcher/history**", async (route) => {
-        await route.fulfill({
-          status: 500,
-          contentType: "application/json",
-          body: JSON.stringify({ detail: "Internal server error" }),
+      await page
+        .context()
+        .route("**/api/v1/agent-switcher/history**", async (route) => {
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "Internal server error" }),
+          });
         });
-      });
-      await page.route("**/api/v1/agent-switcher/activity**", async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify([]),
+      await page
+        .context()
+        .route("**/api/v1/agent-switcher/activity**", async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([]),
+          });
         });
-      });
 
       await page.goto("/auto-switcher/history");
 

--- a/frontend/e2e/auto-switcher-pro-flow.spec.ts
+++ b/frontend/e2e/auto-switcher-pro-flow.spec.ts
@@ -124,65 +124,74 @@ async function setupAutoSwitcherRoutes(
   } = {},
 ) {
   // Settings
-  await page.route("**/api/v1/agent-switcher/settings", async (route) => {
-    if (route.request().method() === "PUT") {
-      const body = JSON.parse(route.request().postData() || "{}");
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/settings", async (route) => {
+      if (route.request().method() === "PUT") {
+        const body = JSON.parse(route.request().postData() || "{}");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ...(overrides.settings ?? MOCK_SETTINGS),
+            ...body,
+          }),
+        });
+        return;
+      }
       await route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({
-          ...(overrides.settings ?? MOCK_SETTINGS),
-          ...body,
-        }),
+        body: JSON.stringify(overrides.settings ?? MOCK_SETTINGS),
       });
-      return;
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(overrides.settings ?? MOCK_SETTINGS),
     });
-  });
 
-  // Activity
-  await page.route("**/api/v1/agent-switcher/activity**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(overrides.activity ?? MOCK_ACTIVITY),
+  // Activity — getActivity() reads `res.activity`, so return an envelope.
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/activity**", async (route) => {
+      const entries = overrides.activity ?? MOCK_ACTIVITY;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ activity: entries, total: entries.length }),
+      });
     });
-  });
 
-  // History
-  await page.route("**/api/v1/agent-switcher/history**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(overrides.history ?? MOCK_ACTIVITY),
+  // History — getHistory() reads `res.history`, so return an envelope.
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/history**", async (route) => {
+      const entries = overrides.history ?? MOCK_ACTIVITY;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ history: entries, total: entries.length }),
+      });
     });
-  });
 
   // Check now — single handler with optional callback
-  await page.route("**/api/v1/agent-switcher/check", async (route) => {
-    overrides.onCheck?.();
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(overrides.checkResult ?? MOCK_CHECK_RESULT),
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/check", async (route) => {
+      overrides.onCheck?.();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(overrides.checkResult ?? MOCK_CHECK_RESULT),
+      });
     });
-  });
 
   // Approve
-  await page.route(
-    "**/api/v1/agent-switcher/audit/*/approve",
-    async (route) => {
+  await page
+    .context()
+    .route("**/api/v1/agent-switcher/audit/*/approve", async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify(overrides.approveResult ?? MOCK_APPROVE_RESULT),
       });
-    },
-  );
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -380,20 +389,24 @@ test.describe("Auto Switcher — Pro Flow", () => {
     { tag: ["@regression"] },
     async ({ authenticatedPage: page }) => {
       // Override settings to return 500
-      await page.route("**/api/v1/agent-switcher/settings", async (route) => {
-        await route.fulfill({
-          status: 500,
-          contentType: "application/json",
-          body: JSON.stringify({ detail: "Internal server error" }),
+      await page
+        .context()
+        .route("**/api/v1/agent-switcher/settings", async (route) => {
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "Internal server error" }),
+          });
         });
-      });
-      await page.route("**/api/v1/agent-switcher/activity**", async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify([]),
+      await page
+        .context()
+        .route("**/api/v1/agent-switcher/activity**", async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify([]),
+          });
         });
-      });
 
       await page.goto("/auto-switcher");
 
@@ -406,20 +419,24 @@ test.describe("Auto Switcher — Pro Flow", () => {
     "handles free tier 403 gracefully",
     { tag: ["@regression"] },
     async ({ authenticatedPage: page }) => {
-      await page.route("**/api/v1/agent-switcher/settings", async (route) => {
-        await route.fulfill({
-          status: 403,
-          contentType: "application/json",
-          body: JSON.stringify({ detail: "Pro tier required" }),
+      await page
+        .context()
+        .route("**/api/v1/agent-switcher/settings", async (route) => {
+          await route.fulfill({
+            status: 403,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "Pro tier required" }),
+          });
         });
-      });
-      await page.route("**/api/v1/agent-switcher/activity**", async (route) => {
-        await route.fulfill({
-          status: 403,
-          contentType: "application/json",
-          body: JSON.stringify({ detail: "Pro tier required" }),
+      await page
+        .context()
+        .route("**/api/v1/agent-switcher/activity**", async (route) => {
+          await route.fulfill({
+            status: 403,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "Pro tier required" }),
+          });
         });
-      });
 
       await page.goto("/auto-switcher");
 

--- a/frontend/e2e/billing-flow.spec.ts
+++ b/frontend/e2e/billing-flow.spec.ts
@@ -90,7 +90,8 @@ test.describe("Billing Flow - Pricing Page", () => {
       await expect(page.getByText("Smart schedule optimization")).toBeVisible();
       await expect(page.getByText("Weather-aware predictions")).toBeVisible();
       await expect(page.getByText("Historical price data")).toBeVisible();
-      await expect(page.getByText("Email notifications")).toBeVisible();
+      // "Email notifications" appears in more than one tier column; scope to first.
+      await expect(page.getByText("Email notifications").first()).toBeVisible();
       await expect(
         page.getByText("Savings tracker & gamification"),
       ).toBeVisible();
@@ -107,7 +108,9 @@ test.describe("Billing Flow - Pricing Page", () => {
       await expect(page.getByText("Multi-property management")).toBeVisible();
       await expect(page.getByText("Priority email support")).toBeVisible();
       await expect(page.getByText("SSE real-time streaming")).toBeVisible();
-      await expect(page.getByText("Dedicated account manager")).toBeVisible();
+      // Business tier's final feature was renamed from "Dedicated account
+      // manager" to "White-glove onboarding".
+      await expect(page.getByText("White-glove onboarding")).toBeVisible();
     },
   );
 

--- a/frontend/e2e/community.spec.ts
+++ b/frontend/e2e/community.spec.ts
@@ -48,7 +48,8 @@ test.describe("Community Page", () => {
     apiMockConfig: {
       communityPosts: COMMUNITY_POSTS,
       communityStats: COMMUNITY_STATS,
-      communityVote: { voted: true },
+      // VoteButton sets its count from the response's upvote_count after click.
+      communityVote: { voted: true, upvote_count: 6 },
     },
   });
 
@@ -87,15 +88,15 @@ test.describe("Community Page", () => {
     async ({ authenticatedPage: page }) => {
       await page.goto("/community");
 
-      // Find the first vote button and click it
-      const voteButtons = page.getByTestId("vote-button");
-      const firstVote = voteButtons.first();
+      // Find the first vote button and click it. VoteButton's testid is
+      // `vote-btn-${postId}`, so match by prefix.
+      const firstVote = page.locator('[data-testid^="vote-btn-"]').first();
       await expect(firstVote).toBeVisible();
 
       // Click to vote
       await firstVote.click();
 
-      // Vote count should update (optimistic: 5 → 6)
+      // Vote count updates from the vote response's upvote_count (mocked to 6).
       await expect(firstVote).toContainText("6");
     },
   );

--- a/frontend/e2e/community.spec.ts
+++ b/frontend/e2e/community.spec.ts
@@ -1,86 +1,102 @@
-import { test, expect } from './fixtures'
-import type { MockCommunityPost } from './helpers/api-mocks'
+import { test, expect } from "./fixtures";
+import type { MockCommunityPost } from "./helpers/api-mocks";
 
 const COMMUNITY_POSTS: MockCommunityPost[] = [
   {
-    id: 'post-1',
-    user_id: 'user-other',
-    region: 'US_CT',
-    utility_type: 'electricity',
-    post_type: 'tip',
-    title: 'Save with off-peak charging',
-    body: 'I switched to charging my EV at night and saved 30%.',
+    id: "post-1",
+    user_id: "user-other",
+    region: "US_CT",
+    utility_type: "electricity",
+    post_type: "tip",
+    title: "Save with off-peak charging",
+    body: "I switched to charging my EV at night and saved 30%.",
     upvotes: 5,
     is_hidden: false,
     is_pending_moderation: false,
     created_at: new Date().toISOString(),
   },
   {
-    id: 'post-2',
-    user_id: 'user-other-2',
-    region: 'US_CT',
-    utility_type: 'electricity',
-    post_type: 'rate_report',
-    title: 'Eversource rate update',
-    body: 'New rate posted for residential.',
+    id: "post-2",
+    user_id: "user-other-2",
+    region: "US_CT",
+    utility_type: "electricity",
+    post_type: "rate_report",
+    title: "Eversource rate update",
+    body: "New rate posted for residential.",
     rate_per_unit: 0.245,
-    rate_unit: 'kWh',
-    supplier_name: 'Eversource',
+    rate_unit: "kWh",
+    supplier_name: "Eversource",
     upvotes: 3,
     is_hidden: false,
     is_pending_moderation: false,
     created_at: new Date().toISOString(),
   },
-]
+];
 
 const COMMUNITY_STATS = {
   total_users: 142,
-  avg_savings_pct: 18.5,
-  top_tip: 'Switch to off-peak usage to save 15-20%',
-  top_tip_author: 'EnergyPro',
-  data_since: '2026-01-15',
-}
+  // CommunityStats renders Math.round(avg_savings_pct)%, so use a whole number
+  // to keep the rendered value unambiguous (18 -> "18%").
+  avg_savings_pct: 18,
+  top_tip: "Switch to off-peak usage to save 15-20%",
+  top_tip_author: "EnergyPro",
+  data_since: "2026-01-15",
+};
 
-test.describe('Community Page', () => {
+test.describe("Community Page", () => {
   test.use({
     apiMockConfig: {
       communityPosts: COMMUNITY_POSTS,
       communityStats: COMMUNITY_STATS,
       communityVote: { voted: true },
     },
-  })
+  });
 
-  test('community page renders post list', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/community')
+  test(
+    "community page renders post list",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/community");
 
-    // Page heading
-    await expect(page.getByRole('heading', { name: 'Community' })).toBeVisible()
+      // Page heading
+      await expect(
+        page.getByRole("heading", { name: "Community" }),
+      ).toBeVisible();
 
-    // Posts should render
-    await expect(page.getByText('Save with off-peak charging')).toBeVisible()
-    await expect(page.getByText('Eversource rate update')).toBeVisible()
-  })
+      // Posts should render
+      await expect(page.getByText("Save with off-peak charging")).toBeVisible();
+      await expect(page.getByText("Eversource rate update")).toBeVisible();
+    },
+  );
 
-  test('community stats banner displays', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/community')
+  test(
+    "community stats banner displays",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/community");
 
-    // Stats banner should show user count and savings
-    await expect(page.getByText('142')).toBeVisible()
-    await expect(page.getByText(/18\.5%/)).toBeVisible()
-  })
+      // Stats banner should show user count and savings (rounded percentage)
+      await expect(page.getByText("142")).toBeVisible();
+      await expect(page.getByText(/18%/)).toBeVisible();
+    },
+  );
 
-  test('vote button updates count on click', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/community')
+  test(
+    "vote button updates count on click",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/community");
 
-    // Find the first vote button and click it
-    const voteButtons = page.getByTestId('vote-button')
-    const firstVote = voteButtons.first()
-    await expect(firstVote).toBeVisible()
+      // Find the first vote button and click it
+      const voteButtons = page.getByTestId("vote-button");
+      const firstVote = voteButtons.first();
+      await expect(firstVote).toBeVisible();
 
-    // Click to vote
-    await firstVote.click()
+      // Click to vote
+      await firstVote.click();
 
-    // Vote count should update (optimistic: 5 → 6)
-    await expect(firstVote).toContainText('6')
-  })
-})
+      // Vote count should update (optimistic: 5 → 6)
+      await expect(firstVote).toContainText("6");
+    },
+  );
+});

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,107 +1,162 @@
-import { test, expect } from './fixtures'
+import { test, expect } from "./fixtures";
 
-test.describe('Dashboard', () => {
-  test('displays dashboard with all main widgets', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+test.describe("Dashboard", () => {
+  test(
+    "displays dashboard with all main widgets",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    // Dashboard title
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+      // Dashboard title
+      await expect(
+        page.getByRole("heading", { name: "Dashboard" }),
+      ).toBeVisible();
 
-    // Current price widget
-    await expect(page.getByText('Current Price').first()).toBeVisible()
-    await expect(page.getByTestId('current-price').first()).toBeVisible()
+      // Current price widget
+      await expect(page.getByText("Current Price").first()).toBeVisible();
+      await expect(page.getByTestId("current-price").first()).toBeVisible();
 
-    // Total saved widget
-    await expect(page.getByText('Total Saved')).toBeVisible()
+      // Total saved widget
+      await expect(page.getByText("Total Saved")).toBeVisible();
 
-    // Optimal times widget
-    await expect(page.getByText('Optimal Times')).toBeVisible()
+      // Optimal times widget
+      await expect(page.getByText("Optimal Times")).toBeVisible();
 
-    // Suppliers widget
-    await expect(page.getByRole('heading', { name: 'Top Suppliers' })).toBeVisible()
-  })
+      // Suppliers widget
+      await expect(
+        page.getByRole("heading", { name: "Top Suppliers" }),
+      ).toBeVisible();
+    },
+  );
 
-  test('shows live prices and trend', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+  test(
+    "shows live prices and trend",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    // Current price should be displayed
-    await expect(page.getByTestId('current-price').first()).toContainText('0.25')
+      // Current price should be displayed
+      await expect(page.getByTestId("current-price").first()).toContainText(
+        "0.25",
+      );
 
-    // Price trend should show decreasing
-    await expect(page.getByTestId('price-trend').first()).toBeVisible()
-  })
+      // Price trend should show decreasing
+      await expect(page.getByTestId("price-trend").first()).toBeVisible();
+    },
+  );
 
-  test('displays price chart with history', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+  test(
+    "displays price chart with history",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    // Wait for chart to load
-    await expect(page.getByText('Price History')).toBeVisible()
+      // Wait for chart to load
+      await expect(page.getByText("Price History")).toBeVisible();
 
-    // Chart container should exist
-    await expect(page.getByTestId('price-chart-container')).toBeVisible()
-  })
+      // Chart container should exist
+      await expect(page.getByTestId("price-chart-container")).toBeVisible();
+    },
+  );
 
-  test('shows 24-hour forecast section', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+  test(
+    "shows 24-hour forecast section",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    await expect(page.getByText('24-Hour Forecast').first()).toBeVisible()
-  })
+      await expect(page.getByText("24-Hour Forecast").first()).toBeVisible();
+    },
+  );
 
-  test('displays supplier comparison widget', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+  test(
+    "displays supplier comparison widget",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    await expect(page.getByText('Top Suppliers')).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Eversource Energy' })).toBeVisible()
-  })
+      await expect(page.getByText("Top Suppliers")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Eversource Energy" }),
+      ).toBeVisible();
+    },
+  );
 
-  test('navigates to prices page', { tag: ['@smoke'] }, async ({ authenticatedPage: page, isMobile }) => {
-    test.skip(isMobile === true, 'Mobile navigation uses different layout')
-    await page.goto('/dashboard')
-    await page.getByText('View all prices').click()
-    await page.waitForURL(/\/prices/, { timeout: 15000 })
-  })
+  test(
+    "navigates to prices page",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page, isMobile }) => {
+      test.skip(isMobile === true, "Mobile navigation uses different layout");
+      await page.goto("/dashboard");
+      await page.getByText("View all prices").click();
+      await page.waitForURL(/\/prices/, { timeout: 15000 });
+    },
+  );
 
   // Client-side navigation from dashboard to suppliers can be slow on webkit
-  test('navigates to suppliers page', { tag: ['@regression'] }, async ({ authenticatedPage: page, isMobile }) => {
-    test.skip(isMobile === true, 'Mobile navigation uses different layout')
-    await page.goto('/dashboard')
-    await page.getByRole('link', { name: 'View all', exact: true }).click()
-    await page.waitForURL(/\/suppliers/, { timeout: 20000 })
-  })
+  test(
+    "navigates to suppliers page",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page, isMobile }) => {
+      test.skip(isMobile === true, "Mobile navigation uses different layout");
+      await page.goto("/dashboard");
+      await page.getByRole("link", { name: "View all", exact: true }).click();
+      await page.waitForURL(/\/suppliers/, { timeout: 20000 });
+    },
+  );
 
   // Realtime indicator has class "hidden sm:flex" — not visible on mobile viewports
-  test('shows realtime indicator', { tag: ['@regression'] }, async ({ authenticatedPage: page, isMobile }) => {
-    test.skip(isMobile === true, 'Realtime indicator is hidden on mobile (sm:flex)')
-    await page.goto('/dashboard')
-    await expect(page.getByTestId('realtime-indicator')).toBeVisible()
-  })
+  test(
+    "shows realtime indicator",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page, isMobile }) => {
+      test.skip(
+        isMobile === true,
+        "Realtime indicator is hidden on mobile (sm:flex)",
+      );
+      await page.goto("/dashboard");
+      await expect(page.getByTestId("realtime-indicator")).toBeVisible();
+    },
+  );
 
-  test('is responsive on mobile', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.setViewportSize({ width: 375, height: 667 })
-    await page.goto('/dashboard')
+  test(
+    "is responsive on mobile",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto("/dashboard");
 
-    // Dashboard should still load
-    await expect(page.getByText('Current Price').first()).toBeVisible()
+      // Dashboard should still load
+      await expect(page.getByText("Current Price").first()).toBeVisible();
 
-    // Sidebar should be hidden on mobile
-    await expect(page.getByRole('navigation')).not.toBeVisible()
-  })
-})
+      // Sidebar should be hidden on mobile. getByRole('navigation') is ambiguous
+      // (the dashboard-tabs nav is also a navigation landmark and IS visible), so
+      // assert a sidebar-only element — the sign-out button — is hidden instead.
+      await expect(page.getByTestId("sign-out-button")).not.toBeVisible();
+    },
+  );
+});
 
-test.describe('Dashboard Error Handling', () => {
-  test('handles API errors gracefully', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    // Override the prices/current mock with a 500 error for this test only
-    await page.route('**/api/v1/prices/current**', async (route) => {
-      await route.fulfill({
-        status: 500,
-        contentType: 'application/json',
-        body: JSON.stringify({ detail: 'Internal server error' }),
-      })
-    })
+test.describe("Dashboard Error Handling", () => {
+  test(
+    "handles API errors gracefully",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      // Override the prices/current mock with a 500 error for this test only
+      await page.route("**/api/v1/prices/current**", async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Internal server error" }),
+        });
+      });
 
-    await page.goto('/dashboard')
+      await page.goto("/dashboard");
 
-    // Dashboard should still render even with API errors
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
-  })
-})
+      // Dashboard should still render even with API errors
+      await expect(
+        page.getByRole("heading", { name: "Dashboard" }),
+      ).toBeVisible();
+    },
+  );
+});

--- a/frontend/e2e/full-journey.spec.ts
+++ b/frontend/e2e/full-journey.spec.ts
@@ -608,8 +608,9 @@ test.describe("Full User Journey - Returning User Flow", () => {
     "returning user sees current supplier info on settings page",
     { tag: ["@regression"] },
     async ({ authenticatedPage: page }) => {
-      // Override user/supplier to return a non-null current supplier
-      await page.route("**/api/v1/user/supplier", async (route) => {
+      // Override user/supplier to return a non-null current supplier.
+      // Context-level so it isn't bypassed by the prod-build routing race.
+      await page.context().route("**/api/v1/user/supplier", async (route) => {
         await route.fulfill({
           status: 200,
           contentType: "application/json",

--- a/frontend/e2e/full-journey.spec.ts
+++ b/frontend/e2e/full-journey.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures'
+import { test, expect } from "./fixtures";
 
 // ---------------------------------------------------------------------------
 // Mock supplier data reused across the Returning User describe block
@@ -6,39 +6,39 @@ import { test, expect } from './fixtures'
 
 const RETURNING_USER_SUPPLIERS = [
   {
-    id: '1',
-    name: 'Eversource Energy',
+    id: "1",
+    name: "Eversource Energy",
     avgPricePerKwh: 0.25,
-    standingCharge: 0.50,
+    standingCharge: 0.5,
     greenEnergy: true,
     rating: 4.5,
     estimatedAnnualCost: 1200,
-    tariffType: 'variable',
+    tariffType: "variable",
   },
   {
-    id: '2',
-    name: 'NextEra Energy',
+    id: "2",
+    name: "NextEra Energy",
     avgPricePerKwh: 0.22,
     standingCharge: 0.45,
     greenEnergy: true,
     rating: 4.3,
     estimatedAnnualCost: 1050,
-    tariffType: 'variable',
+    tariffType: "variable",
     recommended: true,
   },
   {
-    id: '3',
-    name: 'United Illuminating (UI)',
+    id: "3",
+    name: "United Illuminating (UI)",
     avgPricePerKwh: 0.28,
     standingCharge: 0.55,
     greenEnergy: false,
     rating: 3.8,
     estimatedAnnualCost: 1350,
-    tariffType: 'fixed',
+    tariffType: "fixed",
     exitFee: 50,
     current: true,
   },
-]
+];
 
 // ---------------------------------------------------------------------------
 // Full User Journey - Signup to Billing
@@ -49,503 +49,696 @@ const RETURNING_USER_SUPPLIERS = [
 // use `page` directly so they are not inadvertently redirected by the auth cookie.
 // ---------------------------------------------------------------------------
 
-test.describe('Full User Journey - Signup to Billing', () => {
+test.describe("Full User Journey - Signup to Billing", () => {
   // The shared authenticatedPage fixture covers auth + standard API mocks.
   // Tests that visit public pages (/,/pricing,/auth/*) use `page` directly
   // so they are not inadvertently redirected by the auth cookie.
 
-  test('Step 1: Landing page shows hero section and CTA', { tag: ['@smoke'] }, async ({ page }) => {
-    await page.goto('/')
+  test(
+    "Step 1: Landing page shows hero section and CTA",
+    { tag: ["@smoke"] },
+    async ({ page }) => {
+      await page.goto("/");
 
-    // Hero section
-    await expect(page.getByText('Save Money on')).toBeVisible()
-    await expect(page.getByText('Your Electricity Bills', { exact: true })).toBeVisible()
+      // Hero section
+      await expect(page.getByText("Save Money on")).toBeVisible();
+      await expect(
+        page.getByText("Your Electricity Bills", { exact: true }),
+      ).toBeVisible();
 
-    // Description text
-    await expect(page.getByText(/AI-powered price optimization/)).toBeVisible()
+      // Description text
+      await expect(
+        page.getByText(/AI-powered price optimization/),
+      ).toBeVisible();
 
-    // CTAs
-    await expect(page.getByRole('link', { name: 'Start Saving Today' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'View Demo' })).toBeVisible()
+      // CTAs
+      await expect(
+        page.getByRole("link", { name: "Start Saving Today" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Try It Free" }),
+      ).toBeVisible();
 
-    // Nav links
-    await expect(page.getByRole('link', { name: 'Pricing' }).first()).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Sign In' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Get Started' }).first()).toBeVisible()
-  })
+      // Nav links
+      await expect(
+        page.getByRole("link", { name: "Pricing" }).first(),
+      ).toBeVisible();
+      await expect(page.getByRole("link", { name: "Sign In" })).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Get Started" }).first(),
+      ).toBeVisible();
+    },
+  );
 
-  test('Step 1 continued: Landing page shows features section', { tag: ['@regression'] }, async ({ page }) => {
-    await page.goto('/')
+  test(
+    "Step 1 continued: Landing page shows features section",
+    { tag: ["@regression"] },
+    async ({ page }) => {
+      await page.goto("/");
 
-    // Features
-    await expect(page.getByText('Real-Time Price Tracking')).toBeVisible()
-    await expect(page.getByText('Smart Price Alerts')).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'ML-Powered Forecasts' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Schedule Optimization' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'GDPR Compliant' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Weather-Aware' })).toBeVisible()
-  })
+      // Features
+      await expect(page.getByText("Real-Time Price Tracking")).toBeVisible();
+      await expect(page.getByText("Smart Price Alerts")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "ML-Powered Forecasts" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Schedule Optimization" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "GDPR Compliant" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Weather-Aware" }),
+      ).toBeVisible();
+    },
+  );
 
-  test('Step 2: Navigate to signup and fill the form', { tag: ['@smoke'] }, async ({ page }) => {
-    await page.goto('/')
+  test(
+    "Step 2: Navigate to signup and fill the form",
+    { tag: ["@smoke"] },
+    async ({ page }) => {
+      await page.goto("/");
 
-    // Click Get Started from landing page
-    await page.getByRole('link', { name: 'Get Started' }).first().click()
+      // Click Get Started from landing page
+      await page.getByRole("link", { name: "Get Started" }).first().click();
 
-    // Should navigate to signup page
-    await expect(page).toHaveURL(/\/auth\/signup/)
+      // Should navigate to signup page
+      await expect(page).toHaveURL(/\/auth\/signup/);
 
-    // Signup page heading
-    await expect(page.getByRole('heading', { name: /sign up|electricity optimizer/i })).toBeVisible()
+      // Signup page heading (post-rebrand: "RateShift" brand + "Create your account")
+      await expect(
+        page
+          .getByRole("heading", { name: /rateshift|create your account/i })
+          .first(),
+      ).toBeVisible();
 
-    // Fill signup form
-    await page.fill('#email', 'newuser@example.com')
-    await page.fill('#password', 'SecurePass123!')
-    await page.fill('#confirmPassword', 'SecurePass123!')
+      // Fill signup form
+      await page.fill("#email", "newuser@example.com");
+      await page.fill("#password", "SecurePass123!");
+      await page.fill("#confirmPassword", "SecurePass123!");
 
-    // Accept terms
-    await page.check('#terms')
+      // Accept terms
+      await page.check("#terms");
 
-    // Submit form
-    await page.click('button[type="submit"]')
+      // Submit form
+      await page.click('button[type="submit"]');
 
-    // After signup, the mock auth sets a session and redirects. On mobile,
-    // the redirect happens before any confirmation text renders. Use URL-based
-    // assertion which works reliably across all viewports.
-    await page.waitForURL(/\/(onboarding|dashboard|auth)/, { timeout: 10000 })
-  })
+      // After signup, the mock auth sets a session and redirects. On mobile,
+      // the redirect happens before any confirmation text renders. Use URL-based
+      // assertion which works reliably across all viewports.
+      await page.waitForURL(/\/(onboarding|dashboard|auth)/, {
+        timeout: 10000,
+      });
+    },
+  );
 
-  test('Step 3: Signup API responds correctly and user is redirected', { tag: ['@regression'] }, async ({ page }) => {
-    await page.goto('/auth/signup')
+  test(
+    "Step 3: Signup API responds correctly and user is redirected",
+    { tag: ["@regression"] },
+    async ({ page }) => {
+      await page.goto("/auth/signup");
 
-    await page.fill('#email', 'newuser@example.com')
-    await page.fill('#password', 'SecurePass123!')
-    await page.fill('#confirmPassword', 'SecurePass123!')
-    await page.check('#terms')
-    await page.click('button[type="submit"]')
+      await page.fill("#email", "newuser@example.com");
+      await page.fill("#password", "SecurePass123!");
+      await page.fill("#confirmPassword", "SecurePass123!");
+      await page.check("#terms");
+      await page.click('button[type="submit"]');
 
-    // Signup redirects to onboarding for new users
-    await page.waitForURL(/\/(onboarding|dashboard|auth)/, { timeout: 10000 })
-  })
+      // Signup redirects to onboarding for new users
+      await page.waitForURL(/\/(onboarding|dashboard|auth)/, {
+        timeout: 10000,
+      });
+    },
+  );
 
-  test('Step 4: Dashboard loads with price widgets for authenticated user', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    // authenticatedPage already has auth cookie + PRESET_FREE settings + all standard API mocks
+  test(
+    "Step 4: Dashboard loads with price widgets for authenticated user",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      // authenticatedPage already has auth cookie + PRESET_FREE settings + all standard API mocks
 
-    // Override suppliers mock to include the three suppliers used in dashboard assertions
-    await page.route('**/api/v1/suppliers**', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          suppliers: [
-            {
-              id: '1',
-              name: 'Eversource Energy',
-              avgPricePerKwh: 0.25,
-              standingCharge: 0.50,
-              greenEnergy: true,
-              rating: 4.5,
-              estimatedAnnualCost: 1200,
-              tariffType: 'variable',
-              features: ['Smart tariffs', 'App control', '100% renewable'],
-            },
-            {
-              id: '2',
-              name: 'NextEra Energy',
-              avgPricePerKwh: 0.22,
-              standingCharge: 0.45,
-              greenEnergy: true,
-              rating: 4.3,
-              estimatedAnnualCost: 1050,
-              tariffType: 'variable',
-              features: ['Green energy', 'Simple pricing'],
-              recommended: true,
-            },
-          ],
-        }),
-      })
-    })
+      // Override suppliers mock to include the three suppliers used in dashboard assertions
+      await page.route("**/api/v1/suppliers**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            suppliers: [
+              {
+                id: "1",
+                name: "Eversource Energy",
+                avgPricePerKwh: 0.25,
+                standingCharge: 0.5,
+                greenEnergy: true,
+                rating: 4.5,
+                estimatedAnnualCost: 1200,
+                tariffType: "variable",
+                features: ["Smart tariffs", "App control", "100% renewable"],
+              },
+              {
+                id: "2",
+                name: "NextEra Energy",
+                avgPricePerKwh: 0.22,
+                standingCharge: 0.45,
+                greenEnergy: true,
+                rating: 4.3,
+                estimatedAnnualCost: 1050,
+                tariffType: "variable",
+                features: ["Green energy", "Simple pricing"],
+                recommended: true,
+              },
+            ],
+          }),
+        });
+      });
 
-    await page.goto('/dashboard')
+      await page.goto("/dashboard");
 
-    // Dashboard title
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
+      // Dashboard title
+      await expect(
+        page.getByRole("heading", { name: "Dashboard" }),
+      ).toBeVisible();
 
-    // Current price widget
-    await expect(page.getByText('Current Price').first()).toBeVisible()
-    await expect(page.getByTestId('current-price').first()).toBeVisible()
-    await expect(page.getByTestId('current-price').first()).toContainText('0.25')
+      // Current price widget
+      await expect(page.getByText("Current Price").first()).toBeVisible();
+      await expect(page.getByTestId("current-price").first()).toBeVisible();
+      await expect(page.getByTestId("current-price").first()).toContainText(
+        "0.25",
+      );
 
-    // Total saved widget
-    await expect(page.getByText('Total Saved')).toBeVisible()
+      // Total saved widget
+      await expect(page.getByText("Total Saved")).toBeVisible();
 
-    // Optimal times widget
-    await expect(page.getByText('Optimal Times')).toBeVisible()
+      // Optimal times widget
+      await expect(page.getByText("Optimal Times")).toBeVisible();
 
-    // Suppliers widget
-    await expect(page.getByRole('heading', { name: 'Top Suppliers' })).toBeVisible()
+      // Suppliers widget
+      await expect(
+        page.getByRole("heading", { name: "Top Suppliers" }),
+      ).toBeVisible();
 
-    // Price history chart section
-    await expect(page.getByText('Price History')).toBeVisible()
+      // Price history chart section
+      await expect(page.getByText("Price History")).toBeVisible();
 
-    // Forecast section
-    await expect(page.getByText('24-Hour Forecast').first()).toBeVisible()
-  })
+      // Forecast section
+      await expect(page.getByText("24-Hour Forecast").first()).toBeVisible();
+    },
+  );
 
-  test('Step 5: Suppliers page shows supplier comparison', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/suppliers')
+  test(
+    "Step 5: Suppliers page shows supplier comparison",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/suppliers");
 
-    // Supplier comparison heading
-    await expect(page.getByRole('heading', { name: /compare suppliers/i })).toBeVisible()
-  })
+      // Supplier comparison heading
+      await expect(
+        page.getByRole("heading", { name: /compare suppliers/i }),
+      ).toBeVisible();
+    },
+  );
 
-  test('Step 6: Optimize page shows optimization recommendations', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/optimize')
+  test(
+    "Step 6: Optimize page shows optimization recommendations",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/optimize");
 
-    // Optimization page heading
-    await expect(page.getByRole('heading', { name: 'Load Optimization' })).toBeVisible()
+      // Optimization page heading
+      await expect(
+        page.getByRole("heading", { name: "Load Optimization" }),
+      ).toBeVisible();
 
-    // Should show appliance management section
-    await expect(page.getByRole('heading', { name: 'Your Appliances' })).toBeVisible()
+      // Should show appliance management section
+      await expect(
+        page.getByRole("heading", { name: "Your Appliances" }),
+      ).toBeVisible();
 
-    // Quick add buttons for common appliances
-    await expect(page.getByRole('button', { name: /Washing Machine/ })).toBeVisible()
-  })
+      // Quick add buttons for common appliances
+      await expect(
+        page.getByRole("button", { name: /Washing Machine/ }),
+      ).toBeVisible();
+    },
+  );
 
-  test('Step 7: Pricing page shows tier comparison', { tag: ['@smoke'] }, async ({ page }) => {
-    await page.goto('/pricing')
+  test(
+    "Step 7: Pricing page shows tier comparison",
+    { tag: ["@smoke"] },
+    async ({ page }) => {
+      await page.goto("/pricing");
 
-    // Pricing page header
-    await expect(page.getByRole('heading', { name: /simple, transparent pricing/i })).toBeVisible()
+      // Pricing page header
+      await expect(
+        page.getByRole("heading", { name: /simple, transparent pricing/i }),
+      ).toBeVisible();
 
-    // All three tiers
-    await expect(page.getByRole('heading', { name: 'Free' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Pro' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Business' })).toBeVisible()
+      // All three tiers
+      await expect(page.getByRole("heading", { name: "Free" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Pro" })).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Business" }),
+      ).toBeVisible();
 
-    // Prices in USD
-    await expect(page.getByText('$0')).toBeVisible()
-    await expect(page.getByText('$4.99')).toBeVisible()
-    await expect(page.getByText('$14.99')).toBeVisible()
+      // Prices in USD
+      await expect(page.getByText("$0")).toBeVisible();
+      await expect(page.getByText("$4.99")).toBeVisible();
+      await expect(page.getByText("$14.99")).toBeVisible();
 
-    // Pro is highlighted
-    await expect(page.getByText('Most Popular')).toBeVisible()
-  })
+      // Pro is highlighted
+      await expect(page.getByText("Most Popular")).toBeVisible();
+    },
+  );
 
-  test('Step 8: Clicking upgrade navigates to signup with plan parameter', { tag: ['@regression'] }, async ({ page }) => {
-    await page.goto('/pricing')
+  test(
+    "Step 8: Clicking upgrade navigates to signup with plan parameter",
+    { tag: ["@regression"] },
+    async ({ page }) => {
+      await page.goto("/pricing");
 
-    // Click the Pro tier CTA
-    await page.getByRole('link', { name: 'Start Free Trial' }).click()
+      // Click the Pro tier CTA
+      await page.getByRole("link", { name: "Start Free Trial" }).click();
 
-    // Should navigate to signup with plan=pro
-    await expect(page).toHaveURL(/\/auth\/signup\?plan=pro/)
-  })
+      // Should navigate to signup with plan=pro
+      await expect(page).toHaveURL(/\/auth\/signup\?plan=pro/);
+    },
+  );
 
-  test('Full journey: landing to dashboard navigation', { tag: ['@smoke'] }, async ({ page }) => {
-    // Start at landing page
-    await page.goto('/')
-    await expect(page.getByText('Save Money on')).toBeVisible()
+  test(
+    "Full journey: landing to dashboard navigation",
+    { tag: ["@smoke"] },
+    async ({ page }) => {
+      // Start at landing page
+      await page.goto("/");
+      await expect(page.getByText("Save Money on")).toBeVisible();
 
-    // Navigate to signup
-    await page.getByRole('link', { name: 'Start Saving Today' }).click()
-    await expect(page).toHaveURL(/\/auth\/signup/)
+      // Navigate to signup
+      await page.getByRole("link", { name: "Start Saving Today" }).click();
+      await expect(page).toHaveURL(/\/auth\/signup/);
 
-    // Signup page is present
-    await expect(page.getByRole('heading', { name: /sign up|electricity optimizer/i })).toBeVisible()
-  })
+      // Signup page is present (post-rebrand: "RateShift" brand + "Create your account")
+      await expect(
+        page
+          .getByRole("heading", { name: /rateshift|create your account/i })
+          .first(),
+      ).toBeVisible();
+    },
+  );
 
-  test('Full journey: dashboard to suppliers to optimize navigation', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    // authenticatedPage already has auth + PRESET_FREE settings + standard mocks.
-    // Override suppliers to include the specific names used in assertions.
-    await page.route('**/api/v1/suppliers**', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          suppliers: [
-            {
-              id: '1',
-              name: 'Eversource Energy',
-              avgPricePerKwh: 0.25,
-              standingCharge: 0.50,
-              greenEnergy: true,
-              rating: 4.5,
-              estimatedAnnualCost: 1200,
-              tariffType: 'variable',
-            },
-            {
-              id: '2',
-              name: 'NextEra Energy',
-              avgPricePerKwh: 0.22,
-              standingCharge: 0.45,
-              greenEnergy: true,
-              rating: 4.3,
-              estimatedAnnualCost: 1050,
-              tariffType: 'variable',
-              recommended: true,
-            },
-          ],
-        }),
-      })
-    })
+  test(
+    "Full journey: dashboard to suppliers to optimize navigation",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      // authenticatedPage already has auth + PRESET_FREE settings + standard mocks.
+      // Override suppliers to include the specific names used in assertions.
+      await page.route("**/api/v1/suppliers**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            suppliers: [
+              {
+                id: "1",
+                name: "Eversource Energy",
+                avgPricePerKwh: 0.25,
+                standingCharge: 0.5,
+                greenEnergy: true,
+                rating: 4.5,
+                estimatedAnnualCost: 1200,
+                tariffType: "variable",
+              },
+              {
+                id: "2",
+                name: "NextEra Energy",
+                avgPricePerKwh: 0.22,
+                standingCharge: 0.45,
+                greenEnergy: true,
+                rating: 4.3,
+                estimatedAnnualCost: 1050,
+                tariffType: "variable",
+                recommended: true,
+              },
+            ],
+          }),
+        });
+      });
 
-    // Step 1: Start at dashboard
-    await page.goto('/dashboard')
-    await expect(page.getByText('Current Price').first()).toBeVisible()
-    await expect(page.getByTestId('current-price').first()).toContainText('0.25')
+      // Step 1: Start at dashboard
+      await page.goto("/dashboard");
+      await expect(page.getByText("Current Price").first()).toBeVisible();
+      await expect(page.getByTestId("current-price").first()).toContainText(
+        "0.25",
+      );
 
-    // Step 2: Navigate to suppliers via the dashboard link
-    await page.getByRole('link', { name: 'View all', exact: true }).click()
-    await expect(page).toHaveURL('/suppliers')
-    await expect(page.getByRole('heading', { name: 'Eversource Energy' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'NextEra Energy' })).toBeVisible()
-  })
+      // Step 2: Navigate to suppliers via the dashboard link
+      await page.getByRole("link", { name: "View all", exact: true }).click();
+      await expect(page).toHaveURL("/suppliers");
+      await expect(
+        page.getByRole("heading", { name: "Eversource Energy" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "NextEra Energy" }),
+      ).toBeVisible();
+    },
+  );
 
-  test('Full journey: supplier details show pricing in USD', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    // Override suppliers with the three suppliers that have the dollar amounts asserted below
-    await page.route('**/api/v1/suppliers**', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          suppliers: [
-            {
-              id: '1',
-              name: 'Eversource Energy',
-              avgPricePerKwh: 0.25,
-              standingCharge: 0.50,
-              greenEnergy: true,
-              rating: 4.5,
-              estimatedAnnualCost: 1200,
-              tariffType: 'variable',
-            },
-            {
-              id: '2',
-              name: 'NextEra Energy',
-              avgPricePerKwh: 0.22,
-              standingCharge: 0.45,
-              greenEnergy: true,
-              rating: 4.3,
-              estimatedAnnualCost: 1050,
-              tariffType: 'variable',
-              recommended: true,
-            },
-            {
-              id: '3',
-              name: 'United Illuminating (UI)',
-              avgPricePerKwh: 0.28,
-              standingCharge: 0.55,
-              greenEnergy: false,
-              rating: 3.8,
-              estimatedAnnualCost: 1350,
-              tariffType: 'fixed',
-              exitFee: 50,
-            },
-          ],
-        }),
-      })
-    })
+  test(
+    "Full journey: supplier details show pricing in USD",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      // Override suppliers with the three suppliers that have the dollar amounts asserted below
+      await page.route("**/api/v1/suppliers**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            suppliers: [
+              {
+                id: "1",
+                name: "Eversource Energy",
+                avgPricePerKwh: 0.25,
+                standingCharge: 0.5,
+                greenEnergy: true,
+                rating: 4.5,
+                estimatedAnnualCost: 1200,
+                tariffType: "variable",
+              },
+              {
+                id: "2",
+                name: "NextEra Energy",
+                avgPricePerKwh: 0.22,
+                standingCharge: 0.45,
+                greenEnergy: true,
+                rating: 4.3,
+                estimatedAnnualCost: 1050,
+                tariffType: "variable",
+                recommended: true,
+              },
+              {
+                id: "3",
+                name: "United Illuminating (UI)",
+                avgPricePerKwh: 0.28,
+                standingCharge: 0.55,
+                greenEnergy: false,
+                rating: 3.8,
+                estimatedAnnualCost: 1350,
+                tariffType: "fixed",
+                exitFee: 50,
+              },
+            ],
+          }),
+        });
+      });
 
-    await page.goto('/suppliers')
+      await page.goto("/suppliers");
 
-    // Suppliers should be visible
-    await expect(page.getByRole('heading', { name: 'Eversource Energy' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'NextEra Energy' })).toBeVisible()
+      // Suppliers should be visible
+      await expect(
+        page.getByRole("heading", { name: "Eversource Energy" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "NextEra Energy" }),
+      ).toBeVisible();
 
-    // Prices should be displayed (checking for dollar amounts)
-    await expect(page.getByText(/\$1,200|\$1,050|\$1,350/).first()).toBeVisible()
-  })
+      // Prices should be displayed (checking for dollar amounts)
+      await expect(
+        page.getByText(/\$1,200|\$1,050|\$1,350/).first(),
+      ).toBeVisible();
+    },
+  );
 
-  test('Full journey: pricing page footer links work', { tag: ['@regression'] }, async ({ page }) => {
-    await page.goto('/pricing')
+  test(
+    "Full journey: pricing page footer links work",
+    { tag: ["@regression"] },
+    async ({ page }) => {
+      await page.goto("/pricing");
 
-    // Footer links
-    await expect(page.getByRole('link', { name: 'Home' })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Privacy', exact: true })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Terms', exact: true })).toBeVisible()
+      // Footer links
+      await expect(page.getByRole("link", { name: "Home" })).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Privacy", exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Terms", exact: true }),
+      ).toBeVisible();
 
-    // Click Home link
-    await page.getByRole('link', { name: 'Home' }).click()
-    await expect(page).toHaveURL('/')
-  })
-})
+      // Click Home link
+      await page.getByRole("link", { name: "Home" }).click();
+      await expect(page).toHaveURL("/");
+    },
+  );
+});
 
 // ---------------------------------------------------------------------------
 // Full User Journey - Returning User Flow
 // ---------------------------------------------------------------------------
 
-test.describe('Full User Journey - Returning User Flow', () => {
+test.describe("Full User Journey - Returning User Flow", () => {
   // This suite uses authenticatedPage (auth cookie + PRESET_FREE settings + standard mocks).
   // It also needs the current supplier in localStorage, so we use test.use() to supply
   // a richer settings preset, plus override suppliers and prices mocks inline.
 
   test.use({
     settingsPreset: {
-      region: 'US_CT',
+      region: "US_CT",
       annualUsageKwh: 10500,
       peakDemandKw: 3,
       displayPreferences: {
-        currency: 'USD',
-        theme: 'system',
-        timeFormat: '24h',
+        currency: "USD",
+        theme: "system",
+        timeFormat: "24h",
       },
     },
     apiMockConfig: {
-      pricesCurrent: { region: 'US_CT', price: 0.25, trend: 'decreasing', changePercent: -2.5 },
-      savingsSummary: { monthly: 12.50, weekly: 3.25, streak_days: 5 },
+      pricesCurrent: {
+        region: "US_CT",
+        price: 0.25,
+        trend: "decreasing",
+        changePercent: -2.5,
+      },
+      savingsSummary: { monthly: 12.5, weekly: 3.25, streak_days: 5 },
     },
-  })
+  });
 
-  test('returning user lands directly on dashboard', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    // Override suppliers to include the returning user's current supplier
-    await page.route('**/api/v1/suppliers**', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ suppliers: RETURNING_USER_SUPPLIERS }),
-      })
-    })
+  test(
+    "returning user lands directly on dashboard",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      // Override suppliers to include the returning user's current supplier
+      await page.route("**/api/v1/suppliers**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ suppliers: RETURNING_USER_SUPPLIERS }),
+        });
+      });
 
-    await page.goto('/dashboard')
+      await page.goto("/dashboard");
 
-    // Should show dashboard immediately (no redirect)
-    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
-    await expect(page.getByText('Current Price').first()).toBeVisible()
-    await expect(page.getByTestId('current-price').first()).toContainText('0.25')
-  })
+      // Should show dashboard immediately (no redirect)
+      await expect(
+        page.getByRole("heading", { name: "Dashboard" }),
+      ).toBeVisible();
+      await expect(page.getByText("Current Price").first()).toBeVisible();
+      await expect(page.getByTestId("current-price").first()).toContainText(
+        "0.25",
+      );
+    },
+  );
 
-  test('returning user navigates full app: dashboard -> suppliers -> optimize -> settings', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await page.route('**/api/v1/suppliers**', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ suppliers: RETURNING_USER_SUPPLIERS }),
-      })
-    })
+  test(
+    "returning user navigates full app: dashboard -> suppliers -> optimize -> settings",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await page.route("**/api/v1/suppliers**", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ suppliers: RETURNING_USER_SUPPLIERS }),
+        });
+      });
 
-    // Dashboard
-    await page.goto('/dashboard')
-    await expect(page.getByText('Current Price').first()).toBeVisible()
-    await expect(page.getByText('Top Suppliers')).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Eversource Energy' })).toBeVisible()
+      // Dashboard
+      await page.goto("/dashboard");
+      await expect(page.getByText("Current Price").first()).toBeVisible();
+      await expect(page.getByText("Top Suppliers")).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Eversource Energy" }),
+      ).toBeVisible();
 
-    // Navigate to suppliers
-    await page.goto('/suppliers')
-    await expect(page.getByRole('heading', { name: /compare suppliers/i })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Eversource Energy' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'NextEra Energy' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'United Illuminating (UI)' })).toBeVisible()
+      // Navigate to suppliers
+      await page.goto("/suppliers");
+      await expect(
+        page.getByRole("heading", { name: /compare suppliers/i }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Eversource Energy" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "NextEra Energy" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "United Illuminating (UI)" }),
+      ).toBeVisible();
 
-    // Navigate to optimize
-    await page.goto('/optimize')
-    await expect(page.getByRole('heading', { name: 'Load Optimization' })).toBeVisible()
+      // Navigate to optimize
+      await page.goto("/optimize");
+      await expect(
+        page.getByRole("heading", { name: "Load Optimization" }),
+      ).toBeVisible();
 
-    // Navigate to settings
-    await page.goto('/settings')
-    await expect(page.getByRole('heading', { name: 'Account' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Energy Usage' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'Display' })).toBeVisible()
-  })
+      // Navigate to settings
+      await page.goto("/settings");
+      await expect(
+        page.getByRole("heading", { name: "Account" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Energy Usage" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Notifications" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Display" }),
+      ).toBeVisible();
+    },
+  );
 
-  test('returning user sees current supplier info on settings page', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    // Override user/supplier to return a non-null current supplier
-    await page.route('**/api/v1/user/supplier', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          supplier: {
-            id: '3',
-            name: 'United Illuminating (UI)',
-            avgPricePerKwh: 0.28,
-            standingCharge: 0.55,
-            greenEnergy: false,
-            rating: 3.8,
-            estimatedAnnualCost: 1350,
-            tariffType: 'fixed',
-            exitFee: 50,
-          },
-        }),
-      })
-    })
+  test(
+    "returning user sees current supplier info on settings page",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      // Override user/supplier to return a non-null current supplier
+      await page.route("**/api/v1/user/supplier", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            supplier: {
+              id: "3",
+              name: "United Illuminating (UI)",
+              avgPricePerKwh: 0.28,
+              standingCharge: 0.55,
+              greenEnergy: false,
+              rating: 3.8,
+              estimatedAnnualCost: 1350,
+              tariffType: "fixed",
+              exitFee: 50,
+            },
+          }),
+        });
+      });
 
-    await page.goto('/settings')
+      await page.goto("/settings");
 
-    // Current supplier section — use .first() because "Current Supplier" may
-    // appear in both a heading and badge on the suppliers page layout
-    await expect(page.getByText('Current Supplier').first()).toBeVisible()
-    await expect(page.getByText('United Illuminating (UI)').first()).toBeVisible()
-    await expect(page.getByText('Connected').first()).toBeVisible()
-  })
+      // Current supplier section — use .first() because "Current Supplier" may
+      // appear in both a heading and badge on the suppliers page layout
+      await expect(page.getByText("Current Supplier").first()).toBeVisible();
+      await expect(
+        page.getByText("United Illuminating (UI)").first(),
+      ).toBeVisible();
+      await expect(page.getByText("Connected").first()).toBeVisible();
+    },
+  );
 
-  test('returning user can view savings information on dashboard', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+  test(
+    "returning user can view savings information on dashboard",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    // Savings data should be displayed
-    await expect(page.getByText('Total Saved')).toBeVisible()
-    await expect(page.getByText('Savings & Streaks')).toBeVisible()
+      // Savings data should be displayed
+      await expect(page.getByText("Total Saved")).toBeVisible();
+      await expect(page.getByText("Savings & Streaks")).toBeVisible();
 
-    // Streak information
-    await expect(page.getByText(/streak/i).first()).toBeVisible()
-  })
+      // Streak information
+      await expect(page.getByText(/streak/i).first()).toBeVisible();
+    },
+  );
 
-  test('returning user sees price dropping alert on dashboard', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+  test(
+    "returning user sees price dropping alert on dashboard",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    // With trend=decreasing, should show alert banner
-    await expect(page.getByText(/prices dropping/i)).toBeVisible()
-    await expect(page.getByText(/good time for high-energy tasks/i)).toBeVisible()
-  })
+      // With trend=decreasing, should show alert banner
+      await expect(page.getByText(/prices dropping/i)).toBeVisible();
+      await expect(
+        page.getByText(/good time for high-energy tasks/i),
+      ).toBeVisible();
+    },
+  );
 
-  test('returning user can view schedule on dashboard', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await page.goto('/dashboard')
+  test(
+    "returning user can view schedule on dashboard",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/dashboard");
 
-    // Schedule section
-    await expect(page.getByText("Today's Schedule").first()).toBeVisible()
-  })
-})
+      // Schedule section
+      await expect(page.getByText("Today's Schedule").first()).toBeVisible();
+    },
+  );
+});
 
 // ---------------------------------------------------------------------------
 // Full User Journey - Unauthenticated Guard
 // ---------------------------------------------------------------------------
 
-test.describe('Full User Journey - Unauthenticated Guard', () => {
-  test('unauthenticated user is redirected to login from dashboard', { tag: ['@smoke'] }, async ({ page }) => {
-    // Ensure no session cookie — middleware should redirect
-    await page.context().clearCookies()
+test.describe("Full User Journey - Unauthenticated Guard", () => {
+  test(
+    "unauthenticated user is redirected to login from dashboard",
+    { tag: ["@smoke"] },
+    async ({ page }) => {
+      // Ensure no session cookie — middleware should redirect
+      await page.context().clearCookies();
 
-    await page.route('**/api/auth/get-session', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(null),
-      })
-    })
+      await page.route("**/api/auth/get-session", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(null),
+        });
+      });
 
-    await page.goto('/dashboard')
+      await page.goto("/dashboard");
 
-    // Should redirect to login
-    await page.waitForURL(/\/auth\/login/, { timeout: 10000 })
-  })
+      // Should redirect to login
+      await page.waitForURL(/\/auth\/login/, { timeout: 10000 });
+    },
+  );
 
-  test('landing page is accessible without authentication', { tag: ['@smoke'] }, async ({ page }) => {
-    await page.goto('/')
+  test(
+    "landing page is accessible without authentication",
+    { tag: ["@smoke"] },
+    async ({ page }) => {
+      await page.goto("/");
 
-    // Landing page should render fully
-    await expect(page.getByText('Save Money on')).toBeVisible()
-    await expect(page.getByText('Your Electricity Bills', { exact: true })).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Start Saving Today' })).toBeVisible()
-  })
+      // Landing page should render fully
+      await expect(page.getByText("Save Money on")).toBeVisible();
+      await expect(
+        page.getByText("Your Electricity Bills", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Start Saving Today" }),
+      ).toBeVisible();
+    },
+  );
 
-  test('pricing page is accessible without authentication', { tag: ['@smoke'] }, async ({ page }) => {
-    await page.goto('/pricing')
+  test(
+    "pricing page is accessible without authentication",
+    { tag: ["@smoke"] },
+    async ({ page }) => {
+      await page.goto("/pricing");
 
-    // Pricing page should render fully
-    await expect(page.getByRole('heading', { name: /simple, transparent pricing/i })).toBeVisible()
-    await expect(page.getByText('$0')).toBeVisible()
-    await expect(page.getByText('$4.99')).toBeVisible()
-    await expect(page.getByText('$14.99')).toBeVisible()
-  })
-})
+      // Pricing page should render fully
+      await expect(
+        page.getByRole("heading", { name: /simple, transparent pricing/i }),
+      ).toBeVisible();
+      await expect(page.getByText("$0")).toBeVisible();
+      await expect(page.getByText("$4.99")).toBeVisible();
+      await expect(page.getByText("$14.99")).toBeVisible();
+    },
+  );
+});

--- a/frontend/e2e/helpers/api-mocks.ts
+++ b/frontend/e2e/helpers/api-mocks.ts
@@ -8,94 +8,113 @@
  * FIRST (lowest priority), then specific routes override it.
  */
 
-import { Page, Route } from '@playwright/test'
+import { Page, Route } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
 // Mock data types
 // ---------------------------------------------------------------------------
 
 export interface MockPriceData {
-  region?: string
-  price?: number
-  trend?: string
-  changePercent?: number
+  region?: string;
+  price?: number;
+  trend?: string;
+  changePercent?: number;
 }
 
 export interface MockSupplier {
-  id: string
-  name: string
-  avgPricePerKwh: number
-  standingCharge?: number
-  greenEnergy: boolean
-  rating: number
-  estimatedAnnualCost: number
-  tariffType?: string
-  features?: string[]
-  recommended?: boolean
-  exitFee?: number
+  id: string;
+  name: string;
+  avgPricePerKwh: number;
+  standingCharge?: number;
+  greenEnergy: boolean;
+  rating: number;
+  estimatedAnnualCost: number;
+  tariffType?: string;
+  features?: string[];
+  recommended?: boolean;
+  exitFee?: number;
 }
 
 export interface MockUserProfile {
-  email?: string
-  name?: string
-  region?: string
-  utility_types?: string[]
-  current_supplier_id?: string | null
-  annual_usage_kwh?: number
-  onboarding_completed?: boolean
-  subscription_tier?: string
+  email?: string;
+  name?: string;
+  region?: string;
+  utility_types?: string[];
+  current_supplier_id?: string | null;
+  annual_usage_kwh?: number;
+  onboarding_completed?: boolean;
+  subscription_tier?: string;
 }
 
 export interface MockCommunityPost {
-  id: string
-  user_id: string
-  region: string
-  utility_type: string
-  post_type: string
-  title: string
-  body: string
-  upvotes: number
-  rate_per_unit?: number
-  rate_unit?: string
-  supplier_name?: string
-  is_hidden: boolean
-  is_pending_moderation: boolean
-  created_at: string
+  id: string;
+  user_id: string;
+  region: string;
+  utility_type: string;
+  post_type: string;
+  title: string;
+  body: string;
+  upvotes: number;
+  rate_per_unit?: number;
+  rate_unit?: string;
+  supplier_name?: string;
+  is_hidden: boolean;
+  is_pending_moderation: boolean;
+  created_at: string;
 }
 
 export interface MockApiConfig {
   /** Override prices/current response */
-  pricesCurrent?: MockPriceData | false
+  pricesCurrent?: MockPriceData | false;
   /** Override prices/history response */
-  pricesHistory?: object | false
+  pricesHistory?: object | false;
   /** Override prices/forecast response */
-  pricesForecast?: object | false
+  pricesForecast?: object | false;
   /** Override prices/optimal-periods response */
-  optimalPeriods?: object | false
+  optimalPeriods?: object | false;
   /** Override suppliers list response */
-  suppliers?: MockSupplier[] | false
+  suppliers?: MockSupplier[] | false;
   /** Override user profile response */
-  userProfile?: MockUserProfile | false
+  userProfile?: MockUserProfile | false;
   /** Override user/supplier response */
-  userSupplier?: object | false
+  userSupplier?: object | false;
   /** Override savings/summary response */
-  savingsSummary?: object | false
+  savingsSummary?: object | false;
+  /**
+   * Override savings/combined response. Defaults to an empty breakdown.
+   * Consumed by CombinedSavingsCard on the multi-utility "All Utilities" tab,
+   * which does `data.breakdown.map(...)` with no guard — the catch-all's `{}`
+   * leaves breakdown undefined and crashes the tab into the error boundary.
+   */
+  combinedSavings?: object | false;
   /** Override alerts response */
-  alerts?: object | false
+  alerts?: object | false;
   /** Override connections response */
-  connections?: object | false
+  connections?: object | false;
   /** Override agent response */
-  agent?: object | false
+  agent?: object | false;
   /** Override optimization response */
-  optimization?: object | false
+  optimization?: object | false;
   /** Override community posts response */
-  communityPosts?: MockCommunityPost[] | false
+  communityPosts?: MockCommunityPost[] | false;
   /** Override community stats response */
-  communityStats?: object | false
+  communityStats?: object | false;
   /** Override community vote response */
-  communityVote?: object | false
+  communityVote?: object | false;
   /** Override auth session response (null = unauthenticated) */
-  authSession?: object | null | false
+  authSession?: object | null | false;
+  /**
+   * Override the SSE price stream (`/prices/stream`) response body. Provide a
+   * raw `text/event-stream` payload string, or `false` to skip the mock.
+   * Defaults to a single price event derived from `pricesCurrent`.
+   *
+   * IMPORTANT: this endpoint MUST be mocked. The realtime hook
+   * (`useRealtimePrices`) connects via `fetchEventSource`; when the stream is
+   * left to hit the dev/CI backend it errors and trips the apiClient circuit
+   * breaker, flipping the dashboard into its "Unable to load price data"
+   * state. Mocking it keeps the dashboard/prices price widgets rendering.
+   */
+  sseStream?: string | false;
 }
 
 // ---------------------------------------------------------------------------
@@ -103,14 +122,14 @@ export interface MockApiConfig {
 // ---------------------------------------------------------------------------
 
 export interface RouteCall {
-  url: string
-  method: string
-  postData: string | null
-  timestamp: number
+  url: string;
+  method: string;
+  postData: string | null;
+  timestamp: number;
 }
 
 export class ApiCallTracker {
-  private calls: RouteCall[] = []
+  private calls: RouteCall[] = [];
 
   record(route: Route) {
     this.calls.push({
@@ -118,30 +137,31 @@ export class ApiCallTracker {
       method: route.request().method(),
       postData: route.request().postData(),
       timestamp: Date.now(),
-    })
+    });
   }
 
   getCalls(pattern?: string | RegExp, method?: string): RouteCall[] {
     return this.calls.filter((call) => {
-      if (method && call.method !== method) return false
+      if (method && call.method !== method) return false;
       if (pattern) {
-        const regex = typeof pattern === 'string' ? new RegExp(pattern) : pattern
-        return regex.test(call.url)
+        const regex =
+          typeof pattern === "string" ? new RegExp(pattern) : pattern;
+        return regex.test(call.url);
       }
-      return true
-    })
+      return true;
+    });
   }
 
   getCallCount(pattern?: string | RegExp, method?: string): number {
-    return this.getCalls(pattern, method).length
+    return this.getCalls(pattern, method).length;
   }
 
   wasCalled(pattern: string | RegExp, method?: string): boolean {
-    return this.getCallCount(pattern, method) > 0
+    return this.getCallCount(pattern, method) > 0;
   }
 
   reset() {
-    this.calls = []
+    this.calls = [];
   }
 }
 
@@ -150,34 +170,34 @@ export class ApiCallTracker {
 // ---------------------------------------------------------------------------
 
 const DEFAULT_PRICE: MockPriceData = {
-  region: 'US_CT',
+  region: "US_CT",
   price: 0.25,
-  trend: 'stable',
+  trend: "stable",
   changePercent: 0,
-}
+};
 
 const DEFAULT_SUPPLIERS: MockSupplier[] = [
   {
-    id: '1',
-    name: 'Eversource Energy',
+    id: "1",
+    name: "Eversource Energy",
     avgPricePerKwh: 0.25,
     standingCharge: 0.5,
     greenEnergy: true,
     rating: 4.5,
     estimatedAnnualCost: 1200,
-    tariffType: 'variable',
+    tariffType: "variable",
   },
-]
+];
 
 const DEFAULT_PROFILE: MockUserProfile = {
-  email: 'test@example.com',
-  name: 'Test User',
-  region: 'US_CT',
-  utility_types: ['electricity'],
+  email: "test@example.com",
+  name: "Test User",
+  region: "US_CT",
+  utility_types: ["electricity"],
   current_supplier_id: null,
   annual_usage_kwh: 10500,
   onboarding_completed: true,
-}
+};
 
 // ---------------------------------------------------------------------------
 // Main mock registration function
@@ -192,62 +212,107 @@ const DEFAULT_PROFILE: MockUserProfile = {
  */
 export async function createMockApi(
   page: Page,
-  overrides: MockApiConfig = {}
+  overrides: MockApiConfig = {},
 ): Promise<ApiCallTracker> {
-  const tracker = new ApiCallTracker()
+  const tracker = new ApiCallTracker();
+
+  // Register mocks at the BROWSER CONTEXT level rather than the page level.
+  //
+  // Under the production Next.js build, some client requests (notably the
+  // staggered React Query tiers — prices/current, prices/history — and the
+  // `fetchEventSource` SSE stream) intermittently bypass page-level routing
+  // and hit the dev/CI origin, returning 500. When the escaping request is
+  // `prices/current`, `useCurrentPrices` errors and the dashboard flips to its
+  // "Unable to load price data" state. context.route() reliably intercepts
+  // these. Per-test `page.route(...)` overrides still take precedence because
+  // Playwright resolves page routes before context routes.
+  const ctx = page.context();
 
   // --- Catch-all (LIFO: registered first = lowest priority) ---
-  await page.route('**/api/v1/**', async (route) => {
-    tracker.record(route)
+  await ctx.route("**/api/v1/**", async (route) => {
+    tracker.record(route);
     await route.fulfill({
       status: 200,
-      contentType: 'application/json',
+      contentType: "application/json",
       body: JSON.stringify({}),
-    })
-  })
+    });
+  });
 
   // --- Auth session ---
   if (overrides.authSession !== false) {
-    await page.route('**/api/auth/get-session', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/auth/get-session", async (route) => {
+      tracker.record(route);
       const session = overrides.authSession ?? {
         user: {
-          id: 'user_e2e_123',
-          email: 'test@example.com',
-          name: 'Test User',
+          id: "user_e2e_123",
+          email: "test@example.com",
+          name: "Test User",
           emailVerified: true,
         },
         session: {
-          id: 'session_e2e_123',
-          userId: 'user_e2e_123',
-          token: 'mock-session-token-e2e-test',
+          id: "session_e2e_123",
+          userId: "user_e2e_123",
+          token: "mock-session-token-e2e-test",
           expiresAt: new Date(Date.now() + 86400000).toISOString(),
         },
-      }
+      };
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(session),
-      })
-    })
+      });
+    });
+  }
+
+  // --- Prices: SSE stream (realtime) ---
+  // Registered before the price HTTP routes so a per-test `pricesCurrent`
+  // override can feed the default event payload below. `fetchEventSource`
+  // requires a `text/event-stream` content-type or it throws on open.
+  if (overrides.sseStream !== false) {
+    const streamPrice = {
+      ...DEFAULT_PRICE,
+      ...(overrides.pricesCurrent || {}),
+    };
+    const defaultEvent = `data: ${JSON.stringify({
+      region: streamPrice.region,
+      supplier: "Eversource",
+      price_per_kwh: String(streamPrice.price),
+      currency: "USD",
+      is_peak: false,
+      timestamp: new Date().toISOString(),
+      source: "mock",
+    })}\n\n`;
+    await ctx.route("**/api/v1/prices/stream**", async (route) => {
+      tracker.record(route);
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "Cache-Control": "no-cache", Connection: "keep-alive" },
+        // Guarded by `sseStream !== false` above, but narrow for the type checker.
+        body:
+          typeof overrides.sseStream === "string"
+            ? overrides.sseStream
+            : defaultEvent,
+      });
+    });
   }
 
   // --- Prices: current ---
   if (overrides.pricesCurrent !== false) {
-    const priceData = { ...DEFAULT_PRICE, ...(overrides.pricesCurrent || {}) }
-    await page.route('**/api/v1/prices/current**', async (route) => {
-      tracker.record(route)
+    const priceData = { ...DEFAULT_PRICE, ...(overrides.pricesCurrent || {}) };
+    await ctx.route("**/api/v1/prices/current**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify({
           prices: [
             {
               ticker: `ELEC-${priceData.region}`,
               current_price: String(priceData.price),
-              currency: 'USD',
+              currency: "USD",
               region: priceData.region,
-              supplier: 'Eversource',
+              supplier: "Eversource",
               updated_at: new Date().toISOString(),
               is_peak: false,
               carbon_intensity: null,
@@ -261,18 +326,18 @@ export async function createMockApi(
           price: null,
           region: priceData.region,
           timestamp: new Date().toISOString(),
-          source: 'mock',
+          source: "mock",
         }),
-      })
-    })
+      });
+    });
   }
 
   // --- Prices: history ---
   if (overrides.pricesHistory !== false) {
-    await page.route('**/api/v1/prices/history**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/prices/history**", async (route) => {
+      tracker.record(route);
       const data = overrides.pricesHistory ?? {
-        region: 'US_CT',
+        region: "US_CT",
         supplier: null,
         start_date: new Date(Date.now() - 86400000).toISOString(),
         end_date: new Date().toISOString(),
@@ -280,207 +345,227 @@ export async function createMockApi(
         average_price: null,
         min_price: null,
         max_price: null,
-        source: 'mock',
+        source: "mock",
         total: 0,
         page: 1,
         page_size: 24,
         pages: 1,
-      }
+      };
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(data),
-      })
-    })
+      });
+    });
   }
 
   // --- Prices: forecast ---
   if (overrides.pricesForecast !== false) {
-    await page.route('**/api/v1/prices/forecast**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/prices/forecast**", async (route) => {
+      tracker.record(route);
       const data = overrides.pricesForecast ?? {
-        region: 'US_CT',
+        region: "US_CT",
         forecast: {
-          id: 'mock-forecast',
-          region: 'US_CT',
+          id: "mock-forecast",
+          region: "US_CT",
           generated_at: new Date().toISOString(),
           horizon_hours: 24,
           prices: [],
           confidence: 0.85,
-          model_version: 'v1',
+          model_version: "v1",
           source_api: null,
         },
         generated_at: new Date().toISOString(),
         horizon_hours: 24,
         confidence: 0.85,
-        source: 'mock',
-      }
+        source: "mock",
+      };
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(data),
-      })
-    })
+      });
+    });
   }
 
   // --- Prices: optimal periods ---
   if (overrides.optimalPeriods !== false) {
-    await page.route('**/api/v1/prices/optimal-periods**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/prices/optimal-periods**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(overrides.optimalPeriods ?? { periods: [] }),
-      })
-    })
+      });
+    });
   }
 
   // --- Suppliers ---
   if (overrides.suppliers !== false) {
-    await page.route('**/api/v1/suppliers**', async (route) => {
-      tracker.record(route)
-      const url = route.request().url()
-      if (url.includes('/recommendation') || url.includes('/compare')) {
+    await ctx.route("**/api/v1/suppliers**", async (route) => {
+      tracker.record(route);
+      const url = route.request().url();
+      if (url.includes("/recommendation") || url.includes("/compare")) {
         await route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify({ recommendation: null, comparisons: [] }),
-        })
-        return
+        });
+        return;
       }
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify({
           suppliers: overrides.suppliers ?? DEFAULT_SUPPLIERS,
         }),
-      })
-    })
+      });
+    });
   }
 
   // --- User profile ---
   if (overrides.userProfile !== false) {
-    const profile = { ...DEFAULT_PROFILE, ...(overrides.userProfile || {}) }
-    await page.route('**/api/v1/users/profile**', async (route) => {
-      tracker.record(route)
+    const profile = { ...DEFAULT_PROFILE, ...(overrides.userProfile || {}) };
+    await ctx.route("**/api/v1/users/profile**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(profile),
-      })
-    })
+      });
+    });
   }
 
   // --- User supplier ---
   if (overrides.userSupplier !== false) {
-    await page.route('**/api/v1/user/supplier', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/user/supplier", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(overrides.userSupplier ?? { supplier: null }),
-      })
-    })
+      });
+    });
   }
 
   // --- Savings summary ---
   if (overrides.savingsSummary !== false) {
-    await page.route('**/api/v1/savings/summary**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/savings/summary**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(
           overrides.savingsSummary ?? {
             total: 0,
             monthly: 0,
             weekly: 0,
             streak_days: 0,
-            currency: 'USD',
-          }
+            currency: "USD",
+          },
         ),
-      })
-    })
+      });
+    });
+  }
+
+  // --- Savings combined (multi-utility "All Utilities" tab) ---
+  if (overrides.combinedSavings !== false) {
+    await ctx.route("**/api/v1/savings/combined**", async (route) => {
+      tracker.record(route);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          overrides.combinedSavings ?? {
+            total_monthly_savings: 0,
+            breakdown: [],
+          },
+        ),
+      });
+    });
   }
 
   // --- Alerts ---
   if (overrides.alerts !== false) {
-    await page.route('**/api/v1/alerts**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/alerts**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(overrides.alerts ?? { alerts: [] }),
-      })
-    })
+      });
+    });
   }
 
   // --- Connections ---
   if (overrides.connections !== false) {
-    await page.route('**/api/v1/connections**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/connections**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(overrides.connections ?? { connections: [] }),
-      })
-    })
+      });
+    });
   }
 
   // --- Agent ---
   if (overrides.agent !== false) {
-    await page.route('**/api/v1/agent/**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/agent/**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(
-          overrides.agent ?? { usage: { used: 0, limit: 3, remaining: 3 } }
+          overrides.agent ?? { usage: { used: 0, limit: 3, remaining: 3 } },
         ),
-      })
-    })
+      });
+    });
   }
 
   // --- Optimization ---
   if (overrides.optimization !== false) {
-    await page.route('**/api/v1/optimization/**', async (route) => {
-      tracker.record(route)
+    await ctx.route("**/api/v1/optimization/**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(
-          overrides.optimization ?? { schedules: [], recommendations: [] }
+          overrides.optimization ?? { schedules: [], recommendations: [] },
         ),
-      })
-    })
+      });
+    });
   }
 
   // --- Community posts ---
-  if (overrides.communityPosts !== false && overrides.communityPosts !== undefined) {
-    await page.route('**/api/v1/community/posts**', async (route) => {
-      tracker.record(route)
-      if (route.request().method() === 'GET') {
+  if (
+    overrides.communityPosts !== false &&
+    overrides.communityPosts !== undefined
+  ) {
+    await ctx.route("**/api/v1/community/posts**", async (route) => {
+      tracker.record(route);
+      if (route.request().method() === "GET") {
         await route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify({
             posts: overrides.communityPosts,
             total: (overrides.communityPosts as MockCommunityPost[]).length,
             page: 1,
             per_page: 20,
           }),
-        })
-      } else if (route.request().method() === 'POST') {
-        const body = JSON.parse(route.request().postData() || '{}')
+        });
+      } else if (route.request().method() === "POST") {
+        const body = JSON.parse(route.request().postData() || "{}");
         await route.fulfill({
           status: 201,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify({
-            id: 'post-new',
-            user_id: 'user_e2e_123',
-            region: body.region || 'US_CT',
-            utility_type: body.utility_type || 'electricity',
-            post_type: body.post_type || 'tip',
+            id: "post-new",
+            user_id: "user_e2e_123",
+            region: body.region || "US_CT",
+            utility_type: body.utility_type || "electricity",
+            post_type: body.post_type || "tip",
             title: body.title,
             body: body.body,
             upvotes: 0,
@@ -488,34 +573,40 @@ export async function createMockApi(
             is_pending_moderation: true,
             created_at: new Date().toISOString(),
           }),
-        })
+        });
       }
-    })
+    });
   }
 
   // --- Community stats ---
-  if (overrides.communityStats !== false && overrides.communityStats !== undefined) {
-    await page.route('**/api/v1/community/stats**', async (route) => {
-      tracker.record(route)
+  if (
+    overrides.communityStats !== false &&
+    overrides.communityStats !== undefined
+  ) {
+    await ctx.route("**/api/v1/community/stats**", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(overrides.communityStats),
-      })
-    })
+      });
+    });
   }
 
   // --- Community vote ---
-  if (overrides.communityVote !== false && overrides.communityVote !== undefined) {
-    await page.route('**/api/v1/community/posts/*/vote', async (route) => {
-      tracker.record(route)
+  if (
+    overrides.communityVote !== false &&
+    overrides.communityVote !== undefined
+  ) {
+    await ctx.route("**/api/v1/community/posts/*/vote", async (route) => {
+      tracker.record(route);
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify(overrides.communityVote ?? { voted: true }),
-      })
-    })
+      });
+    });
   }
 
-  return tracker
+  return tracker;
 }

--- a/frontend/e2e/helpers/api-mocks.ts
+++ b/frontend/e2e/helpers/api-mocks.ts
@@ -509,7 +509,10 @@ export async function createMockApi(
     });
   }
 
-  // --- Agent ---
+  // --- Agent usage ---
+  // getAgentUsage() reads the response as a flat AgentUsage ({used,limit,remaining}),
+  // so the default must NOT be wrapped in { usage: ... } or AgentChat renders
+  // "undefined/undefined queries today".
   if (overrides.agent !== false) {
     await ctx.route("**/api/v1/agent/**", async (route) => {
       tracker.record(route);
@@ -517,7 +520,7 @@ export async function createMockApi(
         status: 200,
         contentType: "application/json",
         body: JSON.stringify(
-          overrides.agent ?? { usage: { used: 0, limit: 3, remaining: 3 } },
+          overrides.agent ?? { used: 0, limit: 3, remaining: 3 },
         ),
       });
     });

--- a/frontend/e2e/matrix.spec.ts
+++ b/frontend/e2e/matrix.spec.ts
@@ -411,8 +411,11 @@ test.describe("Tier Gating — Pro tier", () => {
       authenticatedPage.locator('h1, [role="heading"]').first(),
     ).toBeVisible({ timeout: 10000 });
 
-    // Supplier name from the default mock should render
-    await expect(authenticatedPage.getByText("Eversource Energy")).toBeVisible({
+    // Supplier name from the default mock should render (appears in the card
+    // and the comparison table, so scope to the first match).
+    await expect(
+      authenticatedPage.getByText("Eversource Energy").first(),
+    ).toBeVisible({
       timeout: 10000,
     });
   });

--- a/frontend/e2e/missing-pages.spec.ts
+++ b/frontend/e2e/missing-pages.spec.ts
@@ -250,12 +250,16 @@ test.describe("ISR Rate Pages", { tag: ["@smoke"] }, () => {
       waitUntil: "domcontentloaded",
     });
 
-    // Next.js returns 404 for invalid dynamic route params.
-    // Verify the HTTP status is 404 AND the page shows a not-found message.
-    expect(response?.status()).toBe(404);
-    await expect(
-      page.getByText(/not found|404|page doesn.t exist/i).first(),
-    ).toBeVisible({ timeout: 5000 });
+    // The route calls notFound() for invalid params. Under Next 16 ISR these
+    // statically-generated rate pages render the not-found UI as a soft 404
+    // (HTTP 200), so accept EITHER a 404 status OR visible not-found content —
+    // matching this test's title. (isVisible() is a one-shot check that races
+    // hydration, so assert the content with the auto-retrying toBeVisible.)
+    if (response?.status() !== 404) {
+      await expect(
+        page.getByText(/not found|404|page doesn.t exist/i).first(),
+      ).toBeVisible({ timeout: 5000 });
+    }
   });
 });
 

--- a/frontend/e2e/missing-pages.spec.ts
+++ b/frontend/e2e/missing-pages.spec.ts
@@ -51,53 +51,9 @@ test.describe("Analytics Page", { tag: ["@regression"] }, () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Beta Signup Page (/beta-signup) — Protected
-// ---------------------------------------------------------------------------
-
-test.describe("Beta Signup Page", { tag: ["@regression"] }, () => {
-  test("loads beta signup form with heading", async ({
-    authenticatedPage: page,
-  }) => {
-    await page.goto("/beta-signup", { waitUntil: "domcontentloaded" });
-
-    await expect(
-      page.getByRole("heading", { name: /sign up free/i }),
-    ).toBeVisible();
-  });
-
-  test("shows required form fields", async ({ authenticatedPage: page }) => {
-    await page.goto("/beta-signup", { waitUntil: "domcontentloaded" });
-
-    // Email and name inputs
-    await expect(page.locator("#email")).toBeVisible();
-    await expect(page.locator("#name")).toBeVisible();
-
-    // ZIP code input
-    await expect(page.locator("#postcode")).toBeVisible();
-
-    // Supplier and monthly bill selects
-    await expect(page.locator("#currentSupplier")).toBeVisible();
-    await expect(page.locator("#monthlyBill")).toBeVisible();
-  });
-
-  test("shows submission button", async ({ authenticatedPage: page }) => {
-    await page.goto("/beta-signup", { waitUntil: "domcontentloaded" });
-
-    await expect(
-      page.getByRole("button", { name: /sign up free/i }),
-    ).toBeVisible();
-  });
-
-  test("shows how did you hear about us field", async ({
-    authenticatedPage: page,
-  }) => {
-    await page.goto("/beta-signup", { waitUntil: "domcontentloaded" });
-
-    await expect(page.locator("#hearAbout")).toBeVisible();
-    await expect(page.getByText(/how did you hear about us/i)).toBeVisible();
-  });
-});
+// NOTE: The /beta-signup page describe was removed — that route no longer
+// exists in the app (returns 404). Beta/waitlist capture has no frontend page;
+// the tests asserted a form that isn't rendered anywhere.
 
 // ---------------------------------------------------------------------------
 // ISR Rate Pages (/rates/[state]/[utility]) — Public, SSR

--- a/frontend/e2e/mobile.spec.ts
+++ b/frontend/e2e/mobile.spec.ts
@@ -21,6 +21,7 @@ import {
   setAuthenticatedState,
   clearAuthState,
 } from "./helpers/auth";
+import { createMockApi } from "./helpers/api-mocks";
 
 // iPhone 14 Pro dimensions — matches Mobile Safari project device
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
@@ -52,189 +53,9 @@ async function setupMobilePage(page: import("@playwright/test").Page) {
     );
   });
 
-  // Register catch-all FIRST (lowest priority — LIFO)
-  await page.route("**/api/v1/**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({}),
-    });
-  });
-
-  await page.route("**/api/auth/get-session", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        user: {
-          id: "user_e2e_123",
-          email: "test@example.com",
-          name: "Test User",
-          emailVerified: true,
-        },
-        session: {
-          id: "session_e2e_123",
-          userId: "user_e2e_123",
-          token: "mock-session-token-e2e-test",
-          expiresAt: new Date(Date.now() + 86400000).toISOString(),
-        },
-      }),
-    });
-  });
-
-  await page.route("**/api/v1/prices/current**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        prices: [
-          {
-            ticker: "ELEC-US_CT",
-            current_price: "0.2500",
-            currency: "USD",
-            region: "US_CT",
-            supplier: "Eversource",
-            updated_at: new Date().toISOString(),
-            is_peak: false,
-            carbon_intensity: null,
-            price_change_24h: null,
-            price: 0.25,
-            timestamp: new Date().toISOString(),
-            trend: "stable",
-            changePercent: 0,
-          },
-        ],
-        price: null,
-        region: "US_CT",
-        timestamp: new Date().toISOString(),
-        source: "mock",
-      }),
-    });
-  });
-
-  await page.route("**/api/v1/prices/history**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        region: "US_CT",
-        prices: [],
-        total: 0,
-        page: 1,
-        page_size: 24,
-        pages: 1,
-        source: "mock",
-      }),
-    });
-  });
-
-  await page.route("**/api/v1/prices/forecast**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        region: "US_CT",
-        forecast: {
-          id: "mock-forecast",
-          region: "US_CT",
-          generated_at: new Date().toISOString(),
-          horizon_hours: 24,
-          prices: [],
-          confidence: 0.85,
-          model_version: "v1",
-          source_api: null,
-        },
-        generated_at: new Date().toISOString(),
-        horizon_hours: 24,
-        confidence: 0.85,
-        source: "mock",
-      }),
-    });
-  });
-
-  await page.route("**/api/v1/prices/optimal-periods**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ periods: [] }),
-    });
-  });
-
-  await page.route("**/api/v1/suppliers**", async (route) => {
-    const url = route.request().url();
-    if (url.includes("/recommendation") || url.includes("/compare")) {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ recommendation: null, comparisons: [] }),
-      });
-      return;
-    }
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        suppliers: [
-          {
-            id: "1",
-            name: "Eversource Energy",
-            avgPricePerKwh: 0.25,
-            standingCharge: 0.5,
-            greenEnergy: true,
-            rating: 4.5,
-            estimatedAnnualCost: 1200,
-            tariffType: "variable",
-          },
-        ],
-      }),
-    });
-  });
-
-  await page.route("**/api/v1/users/profile**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        email: "test@example.com",
-        name: "Test User",
-        region: "US_CT",
-        utility_types: ["electricity"],
-        current_supplier_id: null,
-        annual_usage_kwh: 10500,
-        onboarding_completed: true,
-      }),
-    });
-  });
-
-  await page.route("**/api/v1/user/supplier", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ supplier: null }),
-    });
-  });
-
-  await page.route("**/api/v1/savings/summary**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        total: 0,
-        monthly: 0,
-        weekly: 0,
-        streak_days: 0,
-        currency: "USD",
-      }),
-    });
-  });
-
-  await page.route("**/api/v1/alerts**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ alerts: [] }),
-    });
-  });
+  // All standard API mocks (context-level routing + SSE stream) come from
+  // the shared factory so the mobile dashboard renders like everywhere else.
+  await createMockApi(page, { authSession: false });
 }
 
 // ---------------------------------------------------------------------------
@@ -254,10 +75,11 @@ test.describe("Mobile Navigation", () => {
     });
     await page.waitForSelector("body");
 
-    // The desktop sidebar nav uses class "hidden sm:flex" — it is not
-    // visible at 390px wide (below the sm breakpoint of 640px).
-    const nav = page.getByRole("navigation");
-    await expect(nav).not.toBeVisible();
+    // The desktop sidebar is "hidden lg:flex" — not visible below 1024px.
+    // getByRole('navigation') is ambiguous (the dashboard-tabs nav is also a
+    // navigation landmark and IS visible at mobile), so assert a sidebar-only
+    // element — the sign-out button — is hidden instead.
+    await expect(page.getByTestId("sign-out-button")).not.toBeVisible();
   });
 
   test("hamburger menu button is visible on mobile @regression", async ({

--- a/frontend/e2e/onboarding-flow.spec.ts
+++ b/frontend/e2e/onboarding-flow.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures'
+import { test, expect } from "./fixtures";
 
 /**
  * Onboarding Wizard E2E Tests
@@ -12,7 +12,7 @@ import { test, expect } from './fixtures'
  * conflicts with the onboarding-specific version.
  */
 
-test.describe('Onboarding Wizard Flow', () => {
+test.describe("Onboarding Wizard Flow", () => {
   // Disable the shared factory's userProfile mock so the inline onboarding
   // profile mock (which handles both GET and PUT) is not shadowed.
   test.use({
@@ -21,163 +21,161 @@ test.describe('Onboarding Wizard Flow', () => {
     },
     // New user has no settings yet — use the empty preset
     settingsPreset: {},
-  })
+  });
 
   /** Register the new-user profile mock (GET + PUT) and other onboarding-relevant routes. */
-  async function setupOnboardingMocks(page: import('@playwright/test').Page) {
+  async function setupOnboardingMocks(page: import("@playwright/test").Page) {
     // Profile: GET = new user; PUT = echo body back as updated profile
-    await page.route('**/api/v1/users/profile', async (route, request) => {
-      if (request.method() === 'GET') {
+    await page.route("**/api/v1/users/profile", async (route, request) => {
+      if (request.method() === "GET") {
         await route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify({
-            email: 'test@example.com',
-            name: 'Test User',
+            email: "test@example.com",
+            name: "Test User",
             region: null,
             utility_types: null,
             current_supplier_id: null,
             annual_usage_kwh: null,
             onboarding_completed: false,
           }),
-        })
+        });
       } else {
         // PUT — return updated profile
-        const body = request.postDataJSON()
+        const body = request.postDataJSON();
         await route.fulfill({
           status: 200,
-          contentType: 'application/json',
+          contentType: "application/json",
           body: JSON.stringify({
-            email: 'test@example.com',
-            name: 'Test User',
+            email: "test@example.com",
+            name: "Test User",
             region: body.region || null,
             utility_types: body.utility_types || null,
             current_supplier_id: body.current_supplier_id || null,
             annual_usage_kwh: body.annual_usage_kwh || null,
             onboarding_completed: body.onboarding_completed || false,
           }),
-        })
+        });
       }
-    })
+    });
 
     // Suppliers: TXU and Green Mountain for Texas deregulated flow
-    await page.route('**/api/v1/suppliers**', async (route) => {
+    await page.route("**/api/v1/suppliers**", async (route) => {
       await route.fulfill({
         status: 200,
-        contentType: 'application/json',
+        contentType: "application/json",
         body: JSON.stringify({
           suppliers: [
             {
-              id: 'sup_1',
-              name: 'TXU Energy',
+              id: "sup_1",
+              name: "TXU Energy",
               avgPricePerKwh: 0.12,
               greenEnergy: false,
               rating: 4.2,
               estimatedAnnualCost: 1200,
-              tariffType: 'variable',
+              tariffType: "variable",
             },
             {
-              id: 'sup_2',
-              name: 'Green Mountain Energy',
+              id: "sup_2",
+              name: "Green Mountain Energy",
               avgPricePerKwh: 0.14,
               greenEnergy: true,
               rating: 4.5,
               estimatedAnnualCost: 1400,
-              tariffType: 'fixed',
+              tariffType: "fixed",
             },
           ],
           total: 2,
         }),
-      })
-    })
+      });
+    });
   }
 
-  test('shows multi-step wizard starting with state selection', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await setupOnboardingMocks(page)
-    await page.goto('/onboarding')
+  // NOTE: onboarding was simplified to a SINGLE region-selection step
+  // (OnboardingWizard auto-sets electricity and goes straight to the
+  // dashboard). The former utility-types and supplier steps were removed —
+  // additional utilities are now discovered post-signup on the dashboard.
+  test(
+    "shows the onboarding wizard with state selection",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await setupOnboardingMocks(page);
+      await page.goto("/onboarding");
 
-    await expect(page.getByText('Select your state')).toBeVisible()
-    await expect(page.getByText('Step 1 of')).toBeVisible()
-  })
+      await expect(page.getByText("Select your state")).toBeVisible();
+      await expect(page.getByPlaceholder("Search states...")).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Continue to Dashboard" }),
+      ).toBeVisible();
+    },
+  );
 
-  test('regulated state flow: state -> utility types -> dashboard', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await setupOnboardingMocks(page)
-    await page.goto('/onboarding')
+  test(
+    "regulated state selection completes onboarding and lands on dashboard",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await setupOnboardingMocks(page);
+      await page.goto("/onboarding");
 
-    // Step 1: Select Florida (regulated state)
-    await page.fill('[placeholder="Search states..."]', 'Florida')
-    await page.click('text=Florida')
-    await page.click('text=Continue to Dashboard')
+      // Select Florida (regulated state), then complete straight to the dashboard.
+      await page.fill('[placeholder="Search states..."]', "Florida");
+      await page.click("text=Florida");
+      await page.getByRole("button", { name: "Continue to Dashboard" }).click();
 
-    // Step 2: Utility types (regulated message visible)
-    await expect(page.getByText('What utilities do you use?')).toBeVisible()
-    await expect(page.getByText(/regulated electricity market/)).toBeVisible()
-    await expect(page.getByText('Complete Setup')).toBeVisible()
+      await page.waitForURL(/\/dashboard/, { timeout: 10000 });
+    },
+  );
 
-    // Complete
-    await page.click('text=Complete Setup')
-    await page.waitForURL(/\/dashboard/, { timeout: 10000 })
-  })
+  test(
+    "deregulated state selection completes onboarding and lands on dashboard",
+    { tag: ["@smoke"] },
+    async ({ authenticatedPage: page }) => {
+      await setupOnboardingMocks(page);
+      await page.goto("/onboarding");
 
-  test('deregulated state flow includes supplier step', { tag: ['@smoke'] }, async ({ authenticatedPage: page }) => {
-    await setupOnboardingMocks(page)
-    await page.goto('/onboarding')
+      // Select Texas (deregulated state). The simplified wizard still goes
+      // straight to the dashboard — supplier choice happens later in-app.
+      await page.fill('[placeholder="Search states..."]', "Texas");
+      await page.click("text=Texas");
+      await page.getByRole("button", { name: "Continue to Dashboard" }).click();
 
-    // Step 1: Select Texas (deregulated)
-    await page.fill('[placeholder="Search states..."]', 'Texas')
-    await page.click('text=Texas')
-    await page.click('text=Continue to Dashboard')
+      await page.waitForURL(/\/dashboard/, { timeout: 10000 });
+    },
+  );
 
-    // Step 2: Utility types
-    await expect(page.getByText('What utilities do you use?')).toBeVisible()
-    await page.click('text=Next: Choose Supplier')
+  test(
+    "Continue is disabled until a state is selected",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await setupOnboardingMocks(page);
+      await page.goto("/onboarding");
 
-    // Step 3: Supplier picker
-    await expect(page.getByText('Who is your energy supplier?')).toBeVisible()
-  })
+      const continueBtn = page.getByRole("button", {
+        name: "Continue to Dashboard",
+      });
+      await expect(continueBtn).toBeDisabled();
 
-  test('can skip supplier selection', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await setupOnboardingMocks(page)
-    await page.goto('/onboarding')
+      await page.fill('[placeholder="Search states..."]', "Connecticut");
+      await page.click("text=Connecticut");
+      await expect(continueBtn).toBeEnabled();
+    },
+  );
 
-    // Navigate to supplier step
-    await page.fill('[placeholder="Search states..."]', 'Texas')
-    await page.click('text=Texas')
-    await page.click('text=Continue to Dashboard')
-    await page.click('text=Next: Choose Supplier')
+  test(
+    "search filters the state list and shows an empty state",
+    { tag: ["@regression"] },
+    async ({ authenticatedPage: page }) => {
+      await setupOnboardingMocks(page);
+      await page.goto("/onboarding");
 
-    // Skip supplier — use role selector to avoid matching "Skip to main content" a11y link
-    await page.getByRole('button', { name: 'Skip' }).click()
-    await page.waitForURL(/\/dashboard/, { timeout: 10000 })
-  })
+      await page.fill('[placeholder="Search states..."]', "Texas");
+      await expect(
+        page.getByText("Texas", { exact: false }).first(),
+      ).toBeVisible();
 
-  test('back navigation works between steps', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await setupOnboardingMocks(page)
-    await page.goto('/onboarding')
-
-    // Go to step 2
-    await page.fill('[placeholder="Search states..."]', 'Connecticut')
-    await page.click('text=Connecticut')
-    await page.click('text=Continue to Dashboard')
-
-    await expect(page.getByText('What utilities do you use?')).toBeVisible()
-
-    // Go back
-    await page.click('text=Back')
-    await expect(page.getByText('Select your state')).toBeVisible()
-  })
-
-  test('can select multiple utility types', { tag: ['@regression'] }, async ({ authenticatedPage: page }) => {
-    await setupOnboardingMocks(page)
-    await page.goto('/onboarding')
-
-    // Go to step 2
-    await page.fill('[placeholder="Search states..."]', 'Florida')
-    await page.click('text=Florida')
-    await page.click('text=Continue to Dashboard')
-
-    // Select additional utility type
-    await page.click('text=Natural Gas')
-    await expect(page.getByText('Natural Gas')).toBeVisible()
-  })
-})
+      await page.fill('[placeholder="Search states..."]', "zzzznotastate");
+      await expect(page.getByText(/No states match/)).toBeVisible();
+    },
+  );
+});

--- a/frontend/e2e/prices.spec.ts
+++ b/frontend/e2e/prices.spec.ts
@@ -1,10 +1,26 @@
 import { test, expect } from "./fixtures";
 
-// Build the 24-point history array once at module scope so it stays stable
+// Build the 24-point history array once at module scope so it stays stable.
+// Shape must match the backend ApiPrice contract the UI consumes:
+// price_per_kwh is a Decimal *string* and timestamp is an ISO string. Using
+// {time, price} here previously fed `undefined` into PriceLineChart's
+// parseISO(point.time) → "Cannot read properties of undefined (reading
+// 'split')" → error boundary, hiding the price the test asserts on.
 const now = Date.now();
 const HISTORY_PRICES = Array.from({ length: 24 }, (_, i) => ({
-  time: new Date(now - (23 - i) * 3600000).toISOString(),
-  price: 0.22 + Math.sin(i / 4) * 0.05,
+  timestamp: new Date(now - (23 - i) * 3600000).toISOString(),
+  price_per_kwh: (0.22 + Math.sin(i / 4) * 0.05).toFixed(4),
+  region: "US_CT",
+  supplier: "Eversource",
+}));
+
+// Forecast points share the ApiPrice shape; the forecast response wraps them
+// in a `forecast` *object* (ApiPriceForecastModel), not a bare array.
+const FORECAST_PRICES = Array.from({ length: 24 }, (_, i) => ({
+  timestamp: new Date(now + (i + 1) * 3600000).toISOString(),
+  price_per_kwh: (0.21 + Math.sin(i / 5) * 0.04).toFixed(4),
+  region: "US_CT",
+  supplier: "Eversource",
 }));
 
 test.describe("Prices Page", () => {
@@ -18,12 +34,21 @@ test.describe("Prices Page", () => {
       },
       pricesHistory: { prices: HISTORY_PRICES },
       pricesForecast: {
-        forecast: [
-          { hour: 1, price: 0.23, confidence: [0.21, 0.25] },
-          { hour: 2, price: 0.21, confidence: [0.19, 0.23] },
-          { hour: 3, price: 0.19, confidence: [0.17, 0.21] },
-          { hour: 4, price: 0.2, confidence: [0.18, 0.22] },
-        ],
+        region: "US_CT",
+        forecast: {
+          id: "mock-forecast",
+          region: "US_CT",
+          generated_at: new Date(now).toISOString(),
+          horizon_hours: 24,
+          prices: FORECAST_PRICES,
+          confidence: 0.85,
+          model_version: "v1",
+          source_api: null,
+        },
+        generated_at: new Date(now).toISOString(),
+        horizon_hours: 24,
+        confidence: 0.85,
+        source: "mock",
       },
       optimalPeriods: {
         periods: [

--- a/frontend/lib/api/__tests__/client-circuit-breaker.test.ts
+++ b/frontend/lib/api/__tests__/client-circuit-breaker.test.ts
@@ -254,7 +254,12 @@ describe("apiClient circuit breaker integration", () => {
 
     // Restore Date.now
     Date.now = realDateNow;
-  });
+    // Longer timeout: this test makes real apiClient.get calls whose 5xx
+    // failures trigger real setTimeout backoff retries, so opening the circuit
+    // alone costs several seconds of wall-clock time. Under a loaded full-suite
+    // run the default 5s budget is exceeded (flaky), though it passes in
+    // isolation. The 20s ceiling accommodates the real backoff delays.
+  }, 20000);
 
   it("works for POST requests too", async () => {
     mockFetch.mockResolvedValue(mockJsonResponse({ success: true }));


### PR DESCRIPTION
Resolves the E2E **smoke** failures tracked in #109 and substantially reduces the full-suite regression set that CI runs after the smoke gate.

## Results (verified locally against a production `next build`)
- **Smoke suite: 106/106 green** (was 20 hard-fail + 5 flaky), retries=0.
- **Full chromium regression: touched-spec failures ~33 → ~14** (excludes 12 visual-regression failures that are *platform noise* — committed baselines are `*-linux.png`, green in CI).
- **a11y: 8 → 11 passing** (high-leverage + structural fixes).

## Key root causes fixed (all test-side unless noted)
- **Missing SSE `prices/stream` mock + requests intermittently bypassing page-level routing under the prod build** → registered `createMockApi` mocks at the **browser-context level** (+ added the SSE mock). This was the dashboard "Unable to load price data" cause; per-test `page.route` overrides still win (page > context).
- Wrong-shaped mocks (prices history/forecast), API envelope mismatches (`agent-switcher` history/activity, agent usage), rebrand-stale selectors (RateShift), simplified single-step onboarding wizard, ISR soft-404, sidebar viewport clipping, OAuth build flags, removed dead `/beta-signup` tests.
- **a11y (app code):** Sidebar footer contrast (clears ~22 violations across every protected page), `role="tablist"`, privacy link underline, optimize/settings accessible names, DashboardStatsRow contrast.
- **Flake fix:** raised the timeout on the circuit-breaker half-open recovery test (real-backoff timer test, flaky under loaded full runs).

## ⚠️ Follow-up required (not in this PR)
- **Visual-regression baselines must be regenerated in CI (Linux)** — the a11y visual changes (sidebar text colors) will fail the 12 committed `*-linux.png` baselines until regenerated. Can't be done off-Linux.
- Remaining a11y: small-text brand-color contrast (success/danger/amber/primary) + scattered `text-gray-400` — a design-touching contrast pass.
- App-behavior items: dead price-trend banner (`DashboardContent` hardcodes `trend:"stable"`), session-expired blank state, suppliers error/retry UI.
- A no-backend-only drip assertion (returns 401 against the real CI backend) + CLS/timing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)